### PR TITLE
Intro API, 공통 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ configurations {
 }
 sonarqube {
     properties {
-        property "sonar.projectKey", "co-niverse_co-niverse-backend_AYiROA4IXK3Sz4IwHG2U"
+        property "sonar.projectKey", "co-niverse_dangjang-backend_AYj2jZJELehUZAlqDvRk"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/dangjang/challenge/ChallengeApplication.java
+++ b/src/main/java/dangjang/challenge/ChallengeApplication.java
@@ -2,7 +2,9 @@ package dangjang.challenge;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class ChallengeApplication {
 

--- a/src/main/java/dangjang/challenge/domain/intro/controller/IntroController.java
+++ b/src/main/java/dangjang/challenge/domain/intro/controller/IntroController.java
@@ -1,13 +1,14 @@
 package dangjang.challenge.domain.intro.controller;
 
+import dangjang.challenge.domain.intro.service.IntroService;
+import dangjang.challenge.global.dto.SuccessResponse;
+import dangjang.challenge.global.dto.content.Content;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import dangjang.challenge.domain.intro.service.IntroService;
-import dangjang.challenge.global.dto.SuccessResponse;
-import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/v1/intro")
@@ -17,6 +18,7 @@ public class IntroController {
 
 	@GetMapping
 	public ResponseEntity<SuccessResponse> getIntro() {
-		return ResponseEntity.ok().body(introService.getIntro());
+		Content content = introService.getIntro();
+		return ResponseEntity.ok().body(new SuccessResponse(HttpStatus.OK.getReasonPhrase(), content));
 	}
 }

--- a/src/main/java/dangjang/challenge/domain/intro/controller/IntroController.java
+++ b/src/main/java/dangjang/challenge/domain/intro/controller/IntroController.java
@@ -1,0 +1,22 @@
+package dangjang.challenge.domain.intro.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import dangjang.challenge.domain.intro.service.IntroService;
+import dangjang.challenge.global.dto.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/intro")
+@RequiredArgsConstructor
+public class IntroController {
+	private final IntroService introService;
+
+	@GetMapping
+	public ResponseEntity<SuccessResponse> getIntro() {
+		return ResponseEntity.ok().body(introService.getIntro());
+	}
+}

--- a/src/main/java/dangjang/challenge/domain/intro/service/IntroService.java
+++ b/src/main/java/dangjang/challenge/domain/intro/service/IntroService.java
@@ -1,0 +1,25 @@
+package dangjang.challenge.domain.intro.service;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import dangjang.challenge.global.dto.SuccessResponse;
+import dangjang.challenge.global.dto.content.Content;
+import dangjang.challenge.global.dto.content.SingleContent;
+import dangjang.challenge.global.exception.BadRequestException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class IntroService {
+	private int error = -1;
+
+	public SuccessResponse getIntro() {
+		Content content = new SingleContent<>(null);
+		error += 1;
+		if (error % 2 == 0) {
+			return new SuccessResponse(HttpStatus.OK.getReasonPhrase(), content);
+		}
+		throw new BadRequestException();
+	}
+}

--- a/src/main/java/dangjang/challenge/domain/intro/service/IntroService.java
+++ b/src/main/java/dangjang/challenge/domain/intro/service/IntroService.java
@@ -1,24 +1,21 @@
 package dangjang.challenge.domain.intro.service;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Service;
-
-import dangjang.challenge.global.dto.SuccessResponse;
 import dangjang.challenge.global.dto.content.Content;
 import dangjang.challenge.global.dto.content.SingleContent;
 import dangjang.challenge.global.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class IntroService {
 	private int error = -1;
 
-	public SuccessResponse getIntro() {
+	public Content getIntro() {
 		Content content = new SingleContent<>(null);
 		error += 1;
 		if (error % 2 == 0) {
-			return new SuccessResponse(HttpStatus.OK.getReasonPhrase(), content);
+			return content;
 		}
 		throw new BadRequestException();
 	}

--- a/src/main/java/dangjang/challenge/global/advice/GlobalExceptionAdvice.java
+++ b/src/main/java/dangjang/challenge/global/advice/GlobalExceptionAdvice.java
@@ -1,0 +1,94 @@
+package dangjang.challenge.global.advice;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpServerErrorException;
+
+import dangjang.challenge.global.dto.ErrorResponse;
+import dangjang.challenge.global.exception.BusinessException;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * AOP를 적용하여 전역적으로 발생하는 예외를 처리한다.
+ *
+ * @author Teo
+ * @since 1.0
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionAdvice {
+
+	/**
+	 * 커스텀 예외를 처리한다.
+	 *
+	 * @param e {@link BusinessException}
+	 * @since 1.0
+	 */
+	@ExceptionHandler(BusinessException.class)
+	public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+		log.warn(e.getMessage());
+		int errorCode = e.getErrorCode();
+		ErrorResponse errorResponse = new ErrorResponse(errorCode, e.getMessage());
+		return ResponseEntity.status(errorCode).body(errorResponse);
+	}
+
+	/**
+	 * 요청 헤더가 없을 때 발생하는 예외를 처리한다.
+	 *
+	 * @param e {@link MissingRequestHeaderException}
+	 * @since 1.0
+	 */
+	@ExceptionHandler(MissingRequestHeaderException.class)
+	public ResponseEntity<ErrorResponse> handleMissingRequestHeaderException(MissingRequestHeaderException e) {
+		log.error(e.getMessage());
+		ErrorResponse errorResponse = new ErrorResponse(e.getStatusCode().value(), "잘못된 요청입니다.");
+		return ResponseEntity.badRequest().body(errorResponse);
+	}
+
+	/**
+	 * {@link org.springframework.web.bind.annotation.RequestBody}의 데이터가
+	 * {@link jakarta.validation.Valid}의 유효성 검증에 실패할 때 발생하는 예외를 처리한다.
+	 *
+	 * @param e {@link MethodArgumentNotValidException}
+	 * @since 1.0
+	 */
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+		log.error(e.getMessage());
+		ErrorResponse errorResponse = new ErrorResponse(e.getStatusCode().value(), "잘못된 데이터입니다.", e);
+		return ResponseEntity.badRequest().body(errorResponse);
+	}
+
+	/**
+	 * {@link org.springframework.web.bind.annotation.RequestParam} 또는
+	 * {@link org.springframework.web.bind.annotation.PathVariable}의 데이터가
+	 * {@link org.springframework.validation.annotation.Validated}의 유효성 검증에 실패할 때 발생하는 예외를 처리한다.
+	 * 기본적으로 HTTP status code 500(Internal Server Error)로 처리하기 때문에 400(Bad Request)로 변경한다.
+	 *
+	 * @param e {@link ConstraintViolationException}
+	 * @since 1.0
+	 */
+	@ExceptionHandler(ConstraintViolationException.class)
+	public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
+		log.error(e.getMessage());
+		ErrorResponse errorResponse = new ErrorResponse(400, "잘못된 데이터입니다.", e.getConstraintViolations());
+		return ResponseEntity.badRequest().body(errorResponse);
+	}
+
+	/**
+	 * 서버 내에서 예기치 못한 예외를 처리한다.
+	 *
+	 * @param e {@link HttpServerErrorException}
+	 * @since 1.0
+	 */
+	@ExceptionHandler({RuntimeException.class, HttpServerErrorException.class, Exception.class})
+	public ResponseEntity<ErrorResponse> handleServerErrorException(Exception e) {
+		log.error(e.getMessage());
+		ErrorResponse errorResponse = new ErrorResponse(500, "알 수 없는 에러가 발생했습니다.");
+		return ResponseEntity.internalServerError().body(errorResponse);
+	}
+}

--- a/src/main/java/dangjang/challenge/global/advice/GlobalExceptionAdvice.java
+++ b/src/main/java/dangjang/challenge/global/advice/GlobalExceptionAdvice.java
@@ -50,7 +50,7 @@ public class GlobalExceptionAdvice {
 	@ExceptionHandler(MissingRequestHeaderException.class)
 	public ResponseEntity<ErrorResponse> handleMissingRequestHeaderException(MissingRequestHeaderException e) {
 		log.error(e.getMessage());
-		ErrorResponse errorResponse = new ErrorResponse(e.getStatusCode().value(), "잘못된 요청입니다.");
+		ErrorResponse errorResponse = new ErrorResponse(e.getStatusCode().value(), "올바르지 못한 요청입니다.");
 		return ResponseEntity.badRequest().body(errorResponse);
 	}
 
@@ -63,7 +63,7 @@ public class GlobalExceptionAdvice {
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
 		log.error(e.getMessage());
-		ErrorResponse errorResponse = new ErrorResponse(e.getStatusCode().value(), "잘못된 데이터입니다.", e);
+		ErrorResponse errorResponse = new ErrorResponse(e.getStatusCode().value(), "올바르지 못한 데이터입니다.", e);
 		return ResponseEntity.badRequest().body(errorResponse);
 	}
 
@@ -78,7 +78,7 @@ public class GlobalExceptionAdvice {
 	@ExceptionHandler(ConstraintViolationException.class)
 	public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
 		log.error(e.getMessage());
-		ErrorResponse errorResponse = new ErrorResponse(400, "잘못된 데이터입니다.", e.getConstraintViolations());
+		ErrorResponse errorResponse = new ErrorResponse(400, "올바르지 못한 데이터입니다.", e.getConstraintViolations());
 		return ResponseEntity.badRequest().body(errorResponse);
 	}
 

--- a/src/main/java/dangjang/challenge/global/advice/GlobalExceptionAdvice.java
+++ b/src/main/java/dangjang/challenge/global/advice/GlobalExceptionAdvice.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 /**
  * AOP를 적용하여 전역적으로 발생하는 예외를 처리한다.
@@ -92,5 +93,19 @@ public class GlobalExceptionAdvice {
 		log.error(e.getMessage());
 		ErrorResponse errorResponse = new ErrorResponse(500, "알 수 없는 에러가 발생했습니다.");
 		return ResponseEntity.internalServerError().body(errorResponse);
+	}
+
+	/**
+	 * 잘못된 endpoint로 요청이 전달됐을 때 발생하는 예외를 처리한다.
+	 *
+	 * @param e {@link NoHandlerFoundException}
+	 * @since 1.0
+	 */
+	@ExceptionHandler(NoHandlerFoundException.class)
+	public ResponseEntity<ErrorResponse> handleNoHandlerFoundException(NoHandlerFoundException e) {
+		log.warn(e.getMessage());
+		int errorCode = e.getStatusCode().value();
+		ErrorResponse errorResponse = new ErrorResponse(errorCode, "올바르지 못한 URL 요청입니다.");
+		return ResponseEntity.status(errorCode).body(errorResponse);
 	}
 }

--- a/src/main/java/dangjang/challenge/global/advice/GlobalExceptionAdvice.java
+++ b/src/main/java/dangjang/challenge/global/advice/GlobalExceptionAdvice.java
@@ -1,16 +1,20 @@
 package dangjang.challenge.global.advice;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.MissingRequestHeaderException;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.client.HttpServerErrorException;
-
 import dangjang.challenge.global.dto.ErrorResponse;
 import dangjang.challenge.global.exception.BusinessException;
 import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpServerErrorException;
 
 /**
  * AOP를 적용하여 전역적으로 발생하는 예외를 처리한다.
@@ -50,8 +54,7 @@ public class GlobalExceptionAdvice {
 	}
 
 	/**
-	 * {@link org.springframework.web.bind.annotation.RequestBody}의 데이터가
-	 * {@link jakarta.validation.Valid}의 유효성 검증에 실패할 때 발생하는 예외를 처리한다.
+	 * {@link RequestBody}의 데이터가 {@link Valid}의 유효성 검증에 실패할 때 발생하는 예외를 처리한다.
 	 *
 	 * @param e {@link MethodArgumentNotValidException}
 	 * @since 1.0
@@ -64,9 +67,8 @@ public class GlobalExceptionAdvice {
 	}
 
 	/**
-	 * {@link org.springframework.web.bind.annotation.RequestParam} 또는
-	 * {@link org.springframework.web.bind.annotation.PathVariable}의 데이터가
-	 * {@link org.springframework.validation.annotation.Validated}의 유효성 검증에 실패할 때 발생하는 예외를 처리한다.
+	 * {@link RequestParam} 또는 {@link PathVariable}의 데이터가
+	 * {@link Validated}의 유효성 검증에 실패할 때 발생하는 예외를 처리한다.
 	 * 기본적으로 HTTP status code 500(Internal Server Error)로 처리하기 때문에 400(Bad Request)로 변경한다.
 	 *
 	 * @param e {@link ConstraintViolationException}

--- a/src/main/java/dangjang/challenge/global/config/SecurityConfig.java
+++ b/src/main/java/dangjang/challenge/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package dangjang.challenge.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -23,6 +24,9 @@ import java.util.List;
 @Configuration
 @EnableWebSecurity(debug = true)
 public class SecurityConfig {
+	@Value("${cors.allowed-origins}")
+	private String allowedOrigins;
+
 	/**
 	 * SecurityFilterChain 설정
 	 * <p>
@@ -61,7 +65,7 @@ public class SecurityConfig {
 	@Bean
 	public CorsConfigurationSource configurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.setAllowedOrigins(List.of("*"));
+		configuration.setAllowedOrigins(List.of(allowedOrigins));
 		configuration.setAllowedMethods(List.of("*"));
 		configuration.setAllowedHeaders(List.of("*", "Authorization"));
 		configuration.setAllowCredentials(true);

--- a/src/main/java/dangjang/challenge/global/config/SecurityConfig.java
+++ b/src/main/java/dangjang/challenge/global/config/SecurityConfig.java
@@ -1,7 +1,5 @@
 package dangjang.challenge.global.config;
 
-import java.util.List;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -13,6 +11,8 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 /**
  * Spring Security를 설정한다.

--- a/src/main/java/dangjang/challenge/global/config/SecurityConfig.java
+++ b/src/main/java/dangjang/challenge/global/config/SecurityConfig.java
@@ -23,6 +23,19 @@ import java.util.List;
 @Configuration
 @EnableWebSecurity(debug = true)
 public class SecurityConfig {
+	/**
+	 * SecurityFilterChain 설정
+	 * <p>
+	 * csrf : OAuth2 + JWT를 사용하기 때문에 Stateless하다. 따라서 csrf token을 사용하지 않는다.
+	 * <br/>
+	 * formLogin : 로그인 시 JWT를 생성하는 filter를 적용하므로 formLogin을 사용하지 않는다.
+	 * <br/>
+	 * httpBasic : request header에 id, password를 그대로 노출하므로 보안에 취약하다. JWT를 사용하기 때문에 사용하지 않는다.
+	 * <br/>
+	 * SessionCreationPolicy.STATELESS : 세션을 생성하지 않는다.
+	 *
+	 * @since 1.0
+	 */
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http
@@ -40,6 +53,11 @@ public class SecurityConfig {
 		return http.build();
 	}
 
+	/**
+	 * CORS 설정
+	 *
+	 * @since 1.0
+	 */
 	@Bean
 	public CorsConfigurationSource configurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();

--- a/src/main/java/dangjang/challenge/global/config/SecurityConfig.java
+++ b/src/main/java/dangjang/challenge/global/config/SecurityConfig.java
@@ -1,0 +1,54 @@
+package dangjang.challenge.global.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+/**
+ * Spring Security를 설정한다.
+ *
+ * @author Teo
+ * @since 1.0
+ */
+@Configuration
+@EnableWebSecurity(debug = true)
+public class SecurityConfig {
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.headers(httpSecurityHeadersConfigurer -> httpSecurityHeadersConfigurer.frameOptions(
+				HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+			.csrf(AbstractHttpConfigurer::disable)
+			.cors(corsConfigurer -> corsConfigurer.configurationSource(configurationSource()))
+			.formLogin(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.sessionManagement(
+				sessionManagementConfigurer -> sessionManagementConfigurer.sessionCreationPolicy(
+					SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll());
+
+		return http.build();
+	}
+
+	@Bean
+	public CorsConfigurationSource configurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOrigins(List.of("*"));
+		configuration.setAllowedMethods(List.of("*"));
+		configuration.setAllowedHeaders(List.of("*", "Authorization"));
+		configuration.setAllowCredentials(true);
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
+	}
+}

--- a/src/main/java/dangjang/challenge/global/config/SecurityConfig.java
+++ b/src/main/java/dangjang/challenge/global/config/SecurityConfig.java
@@ -22,7 +22,7 @@ import java.util.List;
  * @since 1.0
  */
 @Configuration
-@EnableWebSecurity(debug = true)
+@EnableWebSecurity
 public class SecurityConfig {
 	@Value("${cors.allowed-origins}")
 	private String allowedOrigins;

--- a/src/main/java/dangjang/challenge/global/config/TimeConfig.java
+++ b/src/main/java/dangjang/challenge/global/config/TimeConfig.java
@@ -1,0 +1,15 @@
+package dangjang.challenge.global.config;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.TimeZone;
+
+@Configuration
+public class TimeConfig {
+
+	@PostConstruct
+	public void setTimeZone() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
+}

--- a/src/main/java/dangjang/challenge/global/config/TimeConfig.java
+++ b/src/main/java/dangjang/challenge/global/config/TimeConfig.java
@@ -5,6 +5,12 @@ import org.springframework.context.annotation.Configuration;
 
 import java.util.TimeZone;
 
+/**
+ * 서버 시간 동기화
+ *
+ * @author Teo
+ * @since 1.0
+ */
 @Configuration
 public class TimeConfig {
 

--- a/src/main/java/dangjang/challenge/global/dto/ErrorResponse.java
+++ b/src/main/java/dangjang/challenge/global/dto/ErrorResponse.java
@@ -1,14 +1,14 @@
 package dangjang.challenge.global.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import org.springframework.validation.BindingResult;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-
-import jakarta.validation.ConstraintViolation;
 
 /**
  * 공통된 에러 응답을 보내기 위해 사용한다.
@@ -32,7 +32,7 @@ public record ErrorResponse(boolean success, int errorCode, String message,
 	}
 
 	/**
-	 * {@link org.springframework.web.bind.MethodArgumentNotValidException}에서 발생한 fieldError를 binding한다.
+	 * {@link MethodArgumentNotValidException}에서 발생한 fieldError를 binding한다.
 	 *
 	 * @since 1.0
 	 */
@@ -48,7 +48,7 @@ public record ErrorResponse(boolean success, int errorCode, String message,
 	}
 
 	/**
-	 * {@link jakarta.validation.ConstraintViolationException}에서 발생한 constraintViolation을 binding한다.
+	 * {@link ConstraintViolationException}에서 발생한 constraintViolation을 binding한다.
 	 *
 	 * @since 1.0
 	 */

--- a/src/main/java/dangjang/challenge/global/dto/ErrorResponse.java
+++ b/src/main/java/dangjang/challenge/global/dto/ErrorResponse.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * 공통된 에러 응답을 보내기 위해 사용한다.
@@ -43,7 +42,7 @@ public record ErrorResponse(boolean success, int errorCode, String message,
 					error.getField(),
 					error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
 					error.getDefaultMessage()))
-				.collect(Collectors.toList());
+				.toList();
 		}
 	}
 
@@ -59,7 +58,7 @@ public record ErrorResponse(boolean success, int errorCode, String message,
 					constraintViolation.getPropertyPath().toString(),
 					constraintViolation.getInvalidValue().toString(),
 					constraintViolation.getMessage()))
-				.collect(Collectors.toList());
+				.toList();
 		}
 	}
 }

--- a/src/main/java/dangjang/challenge/global/dto/ErrorResponse.java
+++ b/src/main/java/dangjang/challenge/global/dto/ErrorResponse.java
@@ -1,0 +1,65 @@
+package dangjang.challenge.global.dto;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.validation.BindingResult;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import jakarta.validation.ConstraintViolation;
+
+/**
+ * 공통된 에러 응답을 보내기 위해 사용한다.
+ *
+ * @author Teo
+ * @since 1.0
+ */
+public record ErrorResponse(boolean success, int errorCode, String message,
+							@JsonInclude(JsonInclude.Include.NON_NULL) List<FieldError> fieldErrors,
+							@JsonInclude(JsonInclude.Include.NON_NULL) List<ConstraintViolationError> violationErrors) {
+	public ErrorResponse(int errorCode, String message) {
+		this(false, errorCode, message, null, null);
+	}
+
+	public ErrorResponse(int errorCode, String message, BindingResult bindingResult) {
+		this(false, errorCode, message, FieldError.of(bindingResult), null);
+	}
+
+	public ErrorResponse(int errorCode, String message, Set<ConstraintViolation<?>> violationErrors) {
+		this(false, errorCode, message, null, ConstraintViolationError.of(violationErrors));
+	}
+
+	/**
+	 * {@link org.springframework.web.bind.MethodArgumentNotValidException}에서 발생한 fieldError를 binding한다.
+	 *
+	 * @since 1.0
+	 */
+	private record FieldError(String field, Object rejectedValue, String reason) {
+		private static List<FieldError> of(BindingResult bindingResult) {
+			return bindingResult.getFieldErrors().stream()
+				.map(error -> new FieldError(
+					error.getField(),
+					error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+					error.getDefaultMessage()))
+				.collect(Collectors.toList());
+		}
+	}
+
+	/**
+	 * {@link jakarta.validation.ConstraintViolationException}에서 발생한 constraintViolation을 binding한다.
+	 *
+	 * @since 1.0
+	 */
+	private record ConstraintViolationError(String propertyPath, Object rejectedValue, String reason) {
+		private static List<ConstraintViolationError> of(Set<ConstraintViolation<?>> constraintViolations) {
+			return constraintViolations.stream()
+				.map(constraintViolation -> new ConstraintViolationError(
+					constraintViolation.getPropertyPath().toString(),
+					constraintViolation.getInvalidValue().toString(),
+					constraintViolation.getMessage()))
+				.collect(Collectors.toList());
+		}
+	}
+}

--- a/src/main/java/dangjang/challenge/global/dto/SuccessResponse.java
+++ b/src/main/java/dangjang/challenge/global/dto/SuccessResponse.java
@@ -1,0 +1,15 @@
+package dangjang.challenge.global.dto;
+
+import dangjang.challenge.global.dto.content.Content;
+
+/**
+ * 공통된 성공 응답을 보내기 위해 사용한다.
+ *
+ * @author Teo
+ * @since 1.0
+ */
+public record SuccessResponse(boolean success, int errorCode, String message, Content data) {
+	public SuccessResponse(String message, Content data) {
+		this(true, 0, message, data);
+	}
+}

--- a/src/main/java/dangjang/challenge/global/dto/content/Content.java
+++ b/src/main/java/dangjang/challenge/global/dto/content/Content.java
@@ -1,5 +1,9 @@
 package dangjang.challenge.global.dto.content;
 
+/**
+ * @author Teo
+ * @since 1.0
+ */
 public interface Content {
 	int minVersion = 50;
 	int latestVersion = 100;

--- a/src/main/java/dangjang/challenge/global/dto/content/Content.java
+++ b/src/main/java/dangjang/challenge/global/dto/content/Content.java
@@ -5,6 +5,10 @@ package dangjang.challenge.global.dto.content;
  * @since 1.0
  */
 public interface Content {
-	int minVersion = 50;
-	int latestVersion = 100;
+	int MIN_VERSION = 50;
+	int LATEST_VERSION = 100;
+
+	int getMinVersion();
+
+	int getLatestVersion();
 }

--- a/src/main/java/dangjang/challenge/global/dto/content/Content.java
+++ b/src/main/java/dangjang/challenge/global/dto/content/Content.java
@@ -1,6 +1,6 @@
 package dangjang.challenge.global.dto.content;
 
 public interface Content {
-	int minVersion = 100;
+	int minVersion = 50;
 	int latestVersion = 100;
 }

--- a/src/main/java/dangjang/challenge/global/dto/content/Content.java
+++ b/src/main/java/dangjang/challenge/global/dto/content/Content.java
@@ -1,0 +1,6 @@
+package dangjang.challenge.global.dto.content;
+
+public interface Content {
+	int minVersion = 100;
+	int latestVersion = 100;
+}

--- a/src/main/java/dangjang/challenge/global/dto/content/MultiContent.java
+++ b/src/main/java/dangjang/challenge/global/dto/content/MultiContent.java
@@ -13,6 +13,16 @@ import java.util.List;
 public record MultiContent<T>(int minVersion, int latestVersion,
 							  @JsonInclude(JsonInclude.Include.NON_NULL) List<T> contents) implements Content {
 	public MultiContent(List<T> contents) {
-		this(Content.minVersion, Content.latestVersion, contents);
+		this(Content.MIN_VERSION, Content.LATEST_VERSION, contents);
+	}
+
+	@Override
+	public int getMinVersion() {
+		return this.minVersion;
+	}
+
+	@Override
+	public int getLatestVersion() {
+		return this.latestVersion;
 	}
 }

--- a/src/main/java/dangjang/challenge/global/dto/content/MultiContent.java
+++ b/src/main/java/dangjang/challenge/global/dto/content/MultiContent.java
@@ -1,0 +1,18 @@
+package dangjang.challenge.global.dto.content;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * 반환할 객체가 여러 개일 때 사용한다.
+ *
+ * @author Teo
+ * @since 1.0
+ */
+public record MultiContent<T>(int minVersion, int latestVersion,
+							  @JsonInclude(JsonInclude.Include.NON_NULL) List<T> contents) implements Content {
+	public MultiContent(List<T> contents) {
+		this(Content.minVersion, Content.latestVersion, contents);
+	}
+}

--- a/src/main/java/dangjang/challenge/global/dto/content/MultiContent.java
+++ b/src/main/java/dangjang/challenge/global/dto/content/MultiContent.java
@@ -1,8 +1,8 @@
 package dangjang.challenge.global.dto.content;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
 
 /**
  * 반환할 객체가 여러 개일 때 사용한다.

--- a/src/main/java/dangjang/challenge/global/dto/content/MultiContent.java
+++ b/src/main/java/dangjang/challenge/global/dto/content/MultiContent.java
@@ -10,19 +10,14 @@ import java.util.List;
  * @author Teo
  * @since 1.0
  */
-public record MultiContent<T>(int minVersion, int latestVersion,
-							  @JsonInclude(JsonInclude.Include.NON_NULL) List<T> contents) implements Content {
-	public MultiContent(List<T> contents) {
-		this(Content.MIN_VERSION, Content.LATEST_VERSION, contents);
-	}
-
+public record MultiContent<T>(@JsonInclude(JsonInclude.Include.NON_NULL) List<T> contents) implements Content {
 	@Override
 	public int getMinVersion() {
-		return this.minVersion;
+		return Content.MIN_VERSION;
 	}
 
 	@Override
 	public int getLatestVersion() {
-		return this.latestVersion;
+		return Content.LATEST_VERSION;
 	}
 }

--- a/src/main/java/dangjang/challenge/global/dto/content/SingleContent.java
+++ b/src/main/java/dangjang/challenge/global/dto/content/SingleContent.java
@@ -8,19 +8,14 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  * @author Teo
  * @since 1.0
  */
-public record SingleContent<T>(int minVersion, int latestVersion, @JsonInclude(JsonInclude.Include.NON_NULL) T content)
-	implements Content {
-	public SingleContent(T content) {
-		this(Content.MIN_VERSION, Content.LATEST_VERSION, content);
-	}
-
+public record SingleContent<T>(@JsonInclude(JsonInclude.Include.NON_NULL) T content) implements Content {
 	@Override
 	public int getMinVersion() {
-		return this.minVersion;
+		return Content.MIN_VERSION;
 	}
 
 	@Override
 	public int getLatestVersion() {
-		return this.latestVersion;
+		return Content.LATEST_VERSION;
 	}
 }

--- a/src/main/java/dangjang/challenge/global/dto/content/SingleContent.java
+++ b/src/main/java/dangjang/challenge/global/dto/content/SingleContent.java
@@ -1,0 +1,16 @@
+package dangjang.challenge.global.dto.content;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * 반환할 객체가 한 개일 때 사용한다.
+ *
+ * @author Teo
+ * @since 1.0
+ */
+public record SingleContent<T>(int minVersion, int latestVersion, @JsonInclude(JsonInclude.Include.NON_NULL) T content)
+	implements Content {
+	public SingleContent(T content) {
+		this(Content.minVersion, Content.latestVersion, content);
+	}
+}

--- a/src/main/java/dangjang/challenge/global/dto/content/SingleContent.java
+++ b/src/main/java/dangjang/challenge/global/dto/content/SingleContent.java
@@ -11,6 +11,16 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 public record SingleContent<T>(int minVersion, int latestVersion, @JsonInclude(JsonInclude.Include.NON_NULL) T content)
 	implements Content {
 	public SingleContent(T content) {
-		this(Content.minVersion, Content.latestVersion, content);
+		this(Content.MIN_VERSION, Content.LATEST_VERSION, content);
+	}
+
+	@Override
+	public int getMinVersion() {
+		return this.minVersion;
+	}
+
+	@Override
+	public int getLatestVersion() {
+		return this.latestVersion;
 	}
 }

--- a/src/main/java/dangjang/challenge/global/exception/BadRequestException.java
+++ b/src/main/java/dangjang/challenge/global/exception/BadRequestException.java
@@ -1,5 +1,9 @@
 package dangjang.challenge.global.exception;
 
+/**
+ * @author Teo
+ * @since 1.0
+ */
 public class BadRequestException extends BusinessException {
 	public BadRequestException() {
 		super(400, "잘못된 요청입니다.");

--- a/src/main/java/dangjang/challenge/global/exception/BadRequestException.java
+++ b/src/main/java/dangjang/challenge/global/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package dangjang.challenge.global.exception;
+
+public class BadRequestException extends BusinessException {
+	public BadRequestException() {
+		super(400, "잘못된 요청입니다.");
+	}
+}

--- a/src/main/java/dangjang/challenge/global/exception/BusinessException.java
+++ b/src/main/java/dangjang/challenge/global/exception/BusinessException.java
@@ -1,0 +1,19 @@
+package dangjang.challenge.global.exception;
+
+import lombok.Getter;
+
+/**
+ * 커스텀 예외를 구현한다.
+ *
+ * @author Teo
+ * @since 1.0
+ */
+@Getter
+public class BusinessException extends RuntimeException {
+	private final int errorCode;
+
+	public BusinessException(int errorCode, String message) {
+		super(message);
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/dangjang/challenge/global/support/BaseEntity.java
+++ b/src/main/java/dangjang/challenge/global/support/BaseEntity.java
@@ -10,6 +10,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+/**
+ * Entity 공통 매핑 정보
+ *
+ * @author Teo
+ * @since 1.0
+ */
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)

--- a/src/main/java/dangjang/challenge/global/support/BaseEntity.java
+++ b/src/main/java/dangjang/challenge/global/support/BaseEntity.java
@@ -1,0 +1,24 @@
+package dangjang.challenge.global.support;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+	@CreatedDate
+	@Column(name = "CREATED_AT", updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "MODIFIED_AT")
+	private LocalDateTime modifiedAt;
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,37 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${DEV_DB_HOST}:3306/${DATABASE_NAME}?characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+  sql:
+    init:
+      mode: always
+      platform: dev
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
+cors:
+  allowed-origins: ${ALLOWED_ORIGINS}
+
+logging:
+  level:
+    org:
+      hibernate:
+        sql: debug
+        type:
+          descriptor:
+            sql: trace
+      springframework:
+        transaction:
+          interceptor: trace
+    web: trace

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${PROD_DB_HOST}:3306/${DATABASE_NAME}?characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: none
+  sql:
+    init:
+      mode: never
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
+cors:
+  allowed-origins: ${ALLOWED_ORIGINS}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,38 @@
+spring:
+  profiles:
+    active: local
+  jpa:
+    properties:
+      hibernate: # TODO 추후 주석 제거
+      #        batch_fetch_style: padded # preparedstatement 쿼리 캐싱 최적화 전략 제어
+      #        default_batch_fetch_size: 100 # in절 query batch size
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    open-in-view: false # OSIV
+  datasource:
+    hikari:
+      connection-timeout: 3000 # connection을 얻기까지 기다리는 최대 시간 (ms)
+      maximum-pool-size: 5 # pool에 유지시킬 수 있는 최대 connection 개수
+    #      auto-commit: false # TODO 추후 주석 제거
+  mvc:
+    throw-exception-if-no-handler-found: true # 요청을 처리할 handler가 존재하지 않을 경우 NoHandlerFoundException
+  web:
+    resources:
+      add-mappings: false # NoHandlerFoundException이 발생했을 때 static resource를 찾지 않음 -> @ExceptionHandler에서 처리
+  lifecycle:
+    timeout-per-shutdown-phase: 20s # graceful하게 요청을 처리하기 위해 서버 종료 시간 유예
+
+server:
+  shutdown: graceful # 남은 요청을 모두 처리하고 서버 종료
+  tomcat: # TODO default 설정 후 부하 테스트하면서 튜닝
+    threads:
+      max: 200 # 동시에 처리할 수 있는 최대 thread 개수
+    accept-count: 100 # max-connections에 도달했을 때 초과된 요청이 쌓이는 queue 사이즈
+    max-connections: 8192 # 서버가 유지할 수 있는 최대 connection 개수
+    max-http-form-post-size: 2MB # POST request body size
+
+jwt:
+  secret-key: ${JWT_SECRET_KEY}
+  access:
+    exp: ${JWT_ACCESS_EXP} # Access Token 만료 시간 (ms)
+  refresh:
+    exp: ${JWT_REFRESH_EXP} # Refresh Token 만료 시간 (ms)

--- a/src/test/java/dangjang/challenge/ControllerTest.java
+++ b/src/test/java/dangjang/challenge/ControllerTest.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.test.web.servlet.MockMvc;
@@ -19,7 +19,7 @@ import org.springframework.util.MultiValueMap;
  * @since 1.0
  */
 @WebMvcTest(includeFilters = @ComponentScan.Filter(classes = {EnableWebSecurity.class}))
-@MockBean(EnableJpaAuditing.class)
+@MockBean(JpaMetamodelMappingContext.class)
 public class ControllerTest {
 	@Autowired
 	private MockMvc mockMvc;

--- a/src/test/java/dangjang/challenge/ControllerTest.java
+++ b/src/test/java/dangjang/challenge/ControllerTest.java
@@ -12,6 +12,12 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.util.MultiValueMap;
 
+/**
+ * WebMvcTest용 공통 메서드이다. 상속하여 사용한다.
+ *
+ * @author Teo
+ * @since 1.0
+ */
 @WebMvcTest(includeFilters = @ComponentScan.Filter(classes = {EnableWebSecurity.class}))
 @MockBean(EnableJpaAuditing.class)
 public class ControllerTest {

--- a/src/test/java/dangjang/challenge/ControllerTest.java
+++ b/src/test/java/dangjang/challenge/ControllerTest.java
@@ -1,0 +1,69 @@
+package dangjang.challenge;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.util.MultiValueMap;
+
+@WebMvcTest(includeFilters = @ComponentScan.Filter(classes = {EnableWebSecurity.class}))
+@MockBean(EnableJpaAuditing.class)
+public class ControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+
+	public ResultActions post(final String uri, final String content, final Object... pathVariables) throws Exception {
+		return mockMvc.perform(
+			MockMvcRequestBuilders.post(uri, pathVariables)
+				.accept(MediaType.APPLICATION_JSON)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(content)
+		);
+	}
+
+	public ResultActions put(final String uri, final String content, final Object... pathVariables) throws Exception {
+		return mockMvc.perform(
+			MockMvcRequestBuilders.put(uri, pathVariables)
+				.accept(MediaType.APPLICATION_JSON)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(content)
+		);
+	}
+
+	public ResultActions patch(final String uri, final String content, final Object... pathVariables) throws Exception {
+		return mockMvc.perform(
+			MockMvcRequestBuilders.patch(uri, pathVariables)
+				.accept(MediaType.APPLICATION_JSON)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(content)
+		);
+	}
+
+	public ResultActions get(final String uri, final Object... pathVariables) throws Exception {
+		return mockMvc.perform(
+			MockMvcRequestBuilders.get(uri, pathVariables)
+				.accept(MediaType.APPLICATION_JSON)
+		);
+	}
+
+	public ResultActions get(final String uri, final MultiValueMap<String, String> params, final Object... pathVariables) throws Exception {
+		return mockMvc.perform(
+			MockMvcRequestBuilders.get(uri, pathVariables)
+				.params(params)
+				.accept(MediaType.APPLICATION_JSON)
+		);
+	}
+
+	public ResultActions delete(final String uri, final Object... pathVariables) throws Exception {
+		return mockMvc.perform(
+			MockMvcRequestBuilders.delete(uri, pathVariables)
+				.accept(MediaType.APPLICATION_JSON)
+		);
+	}
+}

--- a/src/test/java/dangjang/challenge/domain/intro/controller/IntroControllerTest.java
+++ b/src/test/java/dangjang/challenge/domain/intro/controller/IntroControllerTest.java
@@ -18,7 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Teo
  * @since 1.0
  */
-public class IntroControllerTest extends ControllerTest {
+class IntroControllerTest extends ControllerTest {
 	private final String URI = "/api/v1/intro";
 	@MockBean
 	private IntroService introService;

--- a/src/test/java/dangjang/challenge/domain/intro/controller/IntroControllerTest.java
+++ b/src/test/java/dangjang/challenge/domain/intro/controller/IntroControllerTest.java
@@ -36,8 +36,8 @@ public class IntroControllerTest extends ControllerTest {
 		resultActions.andExpectAll(
 			status().isOk(),
 			jsonPath("$.message").value(HttpStatus.OK.getReasonPhrase()),
-			jsonPath("$.data.minVersion").value(Content.minVersion),
-			jsonPath("$.data.latestVersion").value(Content.latestVersion)
+			jsonPath("$.data.minVersion").value(content.getMinVersion()),
+			jsonPath("$.data.latestVersion").value(content.getLatestVersion())
 		);
 	}
 

--- a/src/test/java/dangjang/challenge/domain/intro/controller/IntroControllerTest.java
+++ b/src/test/java/dangjang/challenge/domain/intro/controller/IntroControllerTest.java
@@ -1,0 +1,59 @@
+package dangjang.challenge.domain.intro.controller;
+
+import dangjang.challenge.ControllerTest;
+import dangjang.challenge.domain.intro.service.IntroService;
+import dangjang.challenge.global.dto.content.Content;
+import dangjang.challenge.global.dto.content.SingleContent;
+import dangjang.challenge.global.exception.BadRequestException;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author Teo
+ * @since 1.0
+ */
+public class IntroControllerTest extends ControllerTest {
+	private final String URI = "/api/v1/intro";
+	@MockBean
+	private IntroService introService;
+
+	@Test
+	void 성공한_응답을_반환한다() throws Exception {
+		// given
+		Content content = new SingleContent<>(null);
+		given(introService.getIntro()).willReturn(content);
+
+		// when
+		ResultActions resultActions = get(URI);
+
+		// then
+		resultActions.andExpectAll(
+			status().isOk(),
+			jsonPath("$.message").value(HttpStatus.OK.getReasonPhrase()),
+			jsonPath("$.data.minVersion").value(Content.minVersion),
+			jsonPath("$.data.latestVersion").value(Content.latestVersion)
+		);
+	}
+
+	@Test
+	void 실패한_응답을_반환한다() throws Exception {
+		// given
+		given(introService.getIntro()).willThrow(new BadRequestException());
+
+		// when
+		ResultActions resultActions = get(URI);
+
+		// then
+		resultActions.andExpectAll(
+			status().isBadRequest(),
+			jsonPath("$.errorCode").value(400),
+			jsonPath("$.message").value("잘못된 요청입니다.")
+		);
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,62 @@
+spring:
+  profiles:
+    active: test
+  jpa:
+    properties:
+      hibernate:
+        batch_fetch_style: padded
+        default_batch_fetch_size: 100
+        format_sql: true
+        use_sql_comments: true
+        highlight_sql: true
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    open-in-view: false
+  mvc:
+    throw-exception-if-no-handler-found: true
+  web:
+    resources:
+      add-mappings: false
+
+jwt:
+  secret-key: coniverseconiverseconiverseconiverseconiverseconiverseconiverseconiverseconiverse
+  access:
+    exp: 1800000
+  refresh:
+    exp: 3600000
+
+cors:
+  allowed-origins: "*"
+
+logging:
+  level:
+    org:
+      hibernate:
+        sql: debug
+        type:
+          descriptor:
+            sql: trace
+      springframework:
+        test:
+          context:
+            cache: debug
+        transaction:
+          interceptor: trace
+    web: trace
+
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MYSQL;DB_CLOSE_DELAY=-1
+    username: sa
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  jpa:
+    hibernate:
+      ddl-auto: create
+    defer-datasource-initialization: true

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -60,3 +60,13 @@ spring:
     hibernate:
       ddl-auto: create
     defer-datasource-initialization: true
+  sql:
+    init:
+      mode: always
+
+---
+spring:
+  config:
+    activate:
+      on-profile: performance
+  # ...


### PR DESCRIPTION
# Changes 📝
- Spring Security 설정
- Exception Advice 구현
- Intro API 구현
- 공통 DTO 구현
- application.yml 설정

## Details 🌼
### Spring Security
안드로이드와 빠른 테스트를 위해서 디테일한 설정은 하지 않았습니다 JWT 구현하면서 수정하면 될 것 같아용 handler, filter 등
``` yml
cors:
  allowed-origins: "*"
```
local에서 `allowedOrigins`는 yml 파일에 위와 같이 입력하시면 됩니다
<br>

### Exception Advice
도메인마다 커스텀 예외는 `BusinessException` 클래스를 상속해서 부모 생성자를 호출하는 식으로 구현합니다 하나의 예시가 `BadRequestException`이고, 디렉토리는 특정 도메인용도라면  `domain/{domain}/exception/`이 될 것 같아요!

로직 내에서 커스텀 예외를 던지면 `GlobalExceptionAdvice` 클래스 내의 `@ExceptionHandler(BusinessException.class)` 어노테이션이 설정된 메서드에서 처리하게 돼요
<br>

### Intro API
Response 200 OK
``` json
{
  "sucess" : true,
  "errorCode" : 0,
  "message" : "OK",
  "data" : {
    "minVersion" : 50,
    "latestVersion" : 100
  }
}
```

Response 400 BadRequest
``` json
{
  "sucess" : false,
  "errorCode" : 400,
  "message" : "Bad Request"
}
```

v1은 요구사항대로 위와 같은 response를 전달해요 exception은 서버에서 자체적으로 던져야 하기 때문에 `error`라는 클래스변수를 설정하고 홀수일 때 예외를 던지도록 구현했어요
<br>

### 공통 DTO
response body로 전달될 객체는 `Content` 인터페이스이고, 객체가 하나라면 `SingleContent`, 여러개라면 `MultiContent`를 사용해요
현재 `Content` 인터페이스에 상수로 버전을 명시하고 있는데, 이게 가장 최선의 방법인지 **고민**이에요 
<br>

### application.yml
공통된 properties는 `application.yml`에 설정했고, 환경마다 다른 properties는 확장해서 active하는 형식이에요 log 출력도 비용이고 성능 저하, 보안 문제가 있기 때문에 실제 배포할 때 사용하는 `prod`는 일단 log 관련 설정을 제외했어요 이 부분은 따로 로그 시스템을 구축해야 할 것 같아요
test할 때 사용하는 yml은 `src/test/application.yml`에서 따로 설정합니다
<br>

추후에 수정할 properties는 **TODO**로 남겨놨어요
1. `batch_fetch_size` global 적용 vs `@BatchSize` 어노테이션으로 단일 적용
    - N + 1 문제가 발생하는 연관관계 개수에 따라서 선택 필요

2. `batch_fetch_style: padded`
    - prepared statement는 `IN (?, ...)`의 파라미터 수에 따라 쿼리를 미리 캐싱한다.
    - batch size = 32라면 쿼리를 batch size마다(32개) 만들어야 하기 때문에 성능이 떨어진다. 따라서 최적화하기 위해 batch size가 10보다  클 때까지 2씩 나누면서 쿼리를 만들고 1 ~ 10은 자주 사용하기 떄문에 모두 설정한다.
    - batch size는 1 ~ 10, 16, 32로 총 12개의 쿼리가 생성된다.
    - `batch_fetch_style`이 기본값인 `legacy`일 때 IN절로 가져와야 할 데이터가 31개라면 `(? * 16)`, `(? * 10)` `(? * 5)`쿼리 세 개 발생
    - `batch_fetch_style`가 `padded`일 경우 데이터 크기보다 큰 쿼리를 선택하고 나머지는 padding 처리 -> `(? * 32)`쿼리 한 개 발생
    - ⭐️ 파라미터에 바인딩될 데이터 크기가 어느 정도일지 파악 후 `batch_fetch_size`를 권장 크기인 100 ~ 1000에서 설정 필요

3. `auto-commit: false`
    - 동작 방식 분석 필요
    - 성능 테스트하면서 유효한지 확인 필요

5. tomcat 관련 설정
    - 실제 운영 환경과 같은 스펙의 VM을 사용하는 개발 환경에서 부하 테스트하면서 최적화

## Check List ☑️
- [x] 테스트 코드를 통과했다.
- [x] merge할 브랜치의 위치를 확인했다. (main ❌)
- [x] Assignee를 지정했다.
- [x] Label을 지정했다.

## [Optional] Etc
### Reference
#### batch fetch style
https://docs.jboss.org/hibernate/orm/5.4/javadocs/org/hibernate/loader/BatchFetchStyle.html
https://docs.jboss.org/hibernate/orm/4.2/manual/en-US/html/ch20.html#performance-fetching-batch
https://www.inflearn.com/questions/34469/default-batch-fetch-size-%EA%B4%80%EB%A0%A8%EC%A7%88%EB%AC%B8

#### auto commit
https://pkgonan.github.io/2019/01/hibrnate-autocommit-tuning

#### tomcat 설정
https://tomcat.apache.org/tomcat-8.5-doc/config/http.html
https://velog.io/@myspy/%EC%8A%A4%ED%94%84%EB%A7%81%EB%B6%80%ED%8A%B8-%EC%8A%A4%EB%A0%88%EB%93%9C