### PR TITLE
Jacoco 설정

### DIFF
--- a/.github/workflows/sonarQube.yml
+++ b/.github/workflows/sonarQube.yml
@@ -20,33 +20,33 @@ jobs:
   code-analysis:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-        
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3
-      with:
-        java-version: '17'
-        distribution: 'temurin'
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
-    - name: Cache SonarQube packages
-      uses: actions/cache@v3
-      with:
-        path: ~/.sonar/cache
-        key: ${{ runner.os }}-sonar
-        restore-keys: ${{ runner.os }}-sonar
-        
-    - name: Cache Gradle packages
-      uses: actions/cache@v3
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle
-        
-    - name: Run an analysis of the ${{ github.REF }} branch ${{ github.BASE_REF }} base
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-      run: ./gradlew build -x test sonarqube --info
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache SonarQube packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Run an analysis of the ${{ github.REF }} branch ${{ github.BASE_REF }} base
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        run: ./gradlew build sonarqube --info

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ sonarqube {
         property "sonar.sourceEncoding", "UTF-8"
         property "sonar.sources", "src/main/java"
         property "sonar.tests", "src/test/java"
-        property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/jacoco/jacoco.xml"
+        property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.java.binaries", "${buildDir}/classes"
         property "sonar.test.inclusions", "**/*Test.java"
         property "sonar.exclusions", "**/*Application*, **/*Exception*, **/dto/**, **/global/advice/**, **/global/config/**, **/global/support/**"
@@ -64,7 +64,6 @@ jacocoTestReport {
         html.enabled true
         csv.enabled false
 
-        xml.destination file("${buildDir}/jacoco/jacoco.xml")
         html.destination file("${buildDir}/jacoco/jacoco.html")
     }
     afterEvaluate {

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ sonarqube {
 }
 
 jacoco {
-    toolVersion = "0.8.8"
+    toolVersion = "0.8.10"
 }
 
 jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.1.0'
     id 'io.spring.dependency-management' version '1.1.0'
     id "org.sonarqube" version "3.4.0.2513"
+    id "jacoco"
 }
 
 group = 'dangjang'
@@ -12,11 +13,6 @@ sourceCompatibility = '17'
 configurations {
     compileOnly {
         extendsFrom annotationProcessor
-    }
-}
-sonarqube {
-    properties {
-        property "sonar.projectKey", "co-niverse_dangjang-backend_AYj2jZJELehUZAlqDvRk"
     }
 }
 
@@ -41,4 +37,81 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
+}
+
+sonarqube {
+    properties {
+        property "sonar.projectKey", "co-niverse_dangjang-backend_AYj2jZJELehUZAlqDvRk"
+        property "sonar.language", "java"
+        property "sonar.sourceEncoding", "UTF-8"
+        property "sonar.sources", "src/main/java"
+        property "sonar.tests", "src/test/java"
+        property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/jacoco/jacoco.xml"
+        property "sonar.java.binaries", "${buildDir}/classes"
+        property "sonar.test.inclusions", "**/*Test.java"
+        property "sonar.exclusions", "**/*Application*, **/*Exception*, **/dto/**, **/global/advice/**, **/global/config/**, **/global/support/**"
+    }
+}
+
+jacoco {
+    toolVersion = "0.8.8"
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        html.enabled true
+        csv.enabled false
+
+        xml.destination file("${buildDir}/jacoco/jacoco.xml")
+        html.destination file("${buildDir}/jacoco/jacoco.html")
+    }
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, exclude: [
+                            '**/*Application*',
+                            '**/*Exception*',
+                            '**/dto/**',
+                            '**/global/advice/**',
+                            '**/global/config/**',
+                            '**/global/support/**'
+                    ])
+                })
+        )
+    }
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            element = 'CLASS'
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.70
+            }
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.70
+            }
+            limit {
+                counter = 'LINE'
+                value = 'TOTALCOUNT'
+                maximum = 300
+            }
+            excludes = [
+                    '*.*Application',
+                    '*.*Exception*',
+                    '*.dto.*',
+                    '*.global.advice.*',
+                    '*.global.config.*',
+                    '*.global.support.*'
+            ]
+        }
+    }
 }

--- a/src/test/java/dangjang/challenge/domain/intro/service/IntroServiceTest.java
+++ b/src/test/java/dangjang/challenge/domain/intro/service/IntroServiceTest.java
@@ -1,0 +1,34 @@
+package dangjang.challenge.domain.intro.service;
+
+import dangjang.challenge.global.dto.content.Content;
+import dangjang.challenge.global.exception.BadRequestException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+public class IntroServiceTest {
+	@Autowired
+	private IntroService introService;
+
+	@Test
+	void 호출을_한_번하면_Content가_반환된다() {
+		// when
+		Content content = introService.getIntro();
+
+		// then
+		assertThat(content).isNotNull();
+	}
+
+	@Test
+	void 호출을_두_번하면_BadRequestException이_발생한다() {
+		// given
+		introService.getIntro();
+
+		// when & then
+		assertThatThrownBy(() -> introService.getIntro()).isInstanceOf(BadRequestException.class);
+	}
+}

--- a/src/test/java/dangjang/challenge/domain/intro/service/IntroServiceTest.java
+++ b/src/test/java/dangjang/challenge/domain/intro/service/IntroServiceTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
-public class IntroServiceTest {
+class IntroServiceTest {
 	@Autowired
 	private IntroService introService;
 


### PR DESCRIPTION
# Changes 📝
- jacoco 설정
- Unit Test 추가

## Details 🌼
### Jacoco 설정 방법
1. jacoco 플러그인을 추가합니다
``` gradle
plugins {
    // ...
    id "jacoco"
}
```
<br>

2. 플러그인 버전을 명시합니다
``` gradle
jacoco {
    toolVersion = "0.8.10"

    // 레포트 저장 경로를 변경할 경우
    // reportsDir = file("${buildDir}/custom..")

    // default 경로는 file("${buildDir}/jacoco")
}
```
<br>

3. 바이너리 형태의 커버리지 결과`test.exec`를 사람이 읽기 쉬운 html, xml, csv 등의 파일로 저장하기 위해 레포트를 설정합니다
``` gradle
jacocoTestReport {
    reports {
        xml.enabled true // SonarQube 연동을 위해 사용
        html.enabled true // 사람이 읽기 쉬운 html 파일로 변환
        csv.enabled false // 아직은 csv 파일의 필요성을 느끼지 못해서 false

        html.destination file("${buildDir}/jacoco/jacoco.html") // html 파일 저장 위치
    }
    afterEvaluate {
        classDirectories.setFrom(
                files(classDirectories.files.collect {
                    fileTree(dir: it, exclude: [ // 레포트에서 제외할 클래스 설정
                            '**/*Application*',
                            '**/*Exception*',
                            '**/dto/**',
                            '**/global/advice/**',
                            '**/global/config/**',
                            '**/global/support/**'
                    ])
                })
        )
    }
    finalizedBy 'jacocoTestCoverageVerification' // jacocoTestReport 실행 후 jacocoTestCoverageVerification 실행
}
```
<br>

4. 테스트 실행 후 자동으로 jacocoTestReport를 실행하도록 설정합니다
``` gradle
tasks.named('test') {
    // ...
    finalizedBy 'jacocoTestReport'
}
```
<br>

5. 빌드가 성공하는 커버리지 기준을 설정합니다
``` gradle
jacocoTestCoverageVerification {
    violationRules {
        rule {
            enabled = true // 규칙 활성화
            element = 'CLASS' // 커버리지 측정 단위
            limit {
                counter = 'BRANCH' // 조건문 등의 분기
                value = 'COVEREDRATIO' // 커버된 비율
                minimum = 0.70 // 최소 70%
            }
            limit {
                counter = 'LINE' // 빈 줄을 제외한 코드 라인
                value = 'COVEREDRATIO'
                minimum = 0.70
            }
            limit {
                counter = 'LINE'
                value = 'TOTALCOUNT' // 전체 개수
                maximum = 300 // 최대 300개
            }
            excludes = [ // 커버리지를 체크를 제외할 클래스 설정
                    '*.*Application',
                    '*.*Exception*',
                    '*.dto.*',
                    '*.global.advice.*',
                    '*.global.config.*',
                    '*.global.support.*'
            ]
        }
    }
}
```
<br>

6. SonarQube에 jacoco의 coverage를 적용합니다
``` gradle
sonarqube {
    properties {
        property "sonar.projectKey", "co-niverse_dangjang-backend_AYj2jZJELehUZAlqDvRk"
        property "sonar.language", "java"
        property "sonar.sourceEncoding", "UTF-8"
        property "sonar.sources", "src/main/java"
        property "sonar.tests", "src/test/java"
        property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
        property "sonar.java.binaries", "${buildDir}/classes"
        property "sonar.test.inclusions", "**/*Test.java"
        property "sonar.exclusions", "**/*Application*, **/*Exception*, **/dto/**, **/global/advice/**, **/global/config/**, **/global/support/**"
    }
}
```
<br>

### jacoco 적용 예시
1. `./gradew build`로 빌드했을 때 커버리지 기준을 만족하지 못해 빌드에 실패합니다
<div align=center>
<img src="https://github.com/co-niverse/dangjang-backend/assets/101033262/f3bd36da-4413-4ff5-8bcc-76ce522a0c68">
<img src="https://github.com/co-niverse/dangjang-backend/assets/101033262/a5f3e7a1-79bc-4916-917c-3279fea5c5be">
<img src="https://github.com/co-niverse/dangjang-backend/assets/101033262/b52b33e6-09ed-4286-b083-336a2c6e4ca7">
</div>
<br>

2. 커버리지 기준을 만족하면 빌드에 성공합니다
<div align=center>
<img src="https://github.com/co-niverse/dangjang-backend/assets/101033262/75099625-0303-47dc-8937-4fb583fef939">
<img src="https://github.com/co-niverse/dangjang-backend/assets/101033262/8dc66d88-e5c3-4305-be69-1657e04e02ac">
<img src="https://github.com/co-niverse/dangjang-backend/assets/101033262/424199e1-2f04-488c-9a7b-656abdacc2cf">
</div>
<br>

## Check List ☑️
- [x] 테스트 코드를 통과했다.
- [x] merge할 브랜치의 위치를 확인했다. (main ❌)
- [x] Assignee를 지정했다.
- [x] Label을 지정했다.

## [Optional] Etc
### Reference
https://www.eclemma.org/jacoco/
https://techblog.woowahan.com/2661/
https://velog.io/@max9106/%EC%A0%95%EC%A0%81-%EB%B6%84%EC%84%9D-with-Jacoco-SonarQube