### PR TITLE
회원가입&닉네임중복여부 기능

### DIFF
--- a/src/main/java/com/coniverse/dangjang/domain/auth/dto/Response/LoginResponse.java
+++ b/src/main/java/com/coniverse/dangjang/domain/auth/dto/Response/LoginResponse.java
@@ -12,9 +12,9 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class LoginResponse {
-	private String oauthId;
 	private String nickname;
 	private String accessToken;
 	private String refreshToken;
-	private Long expiresIn;
+	private Boolean premium;
+	private Boolean healthConnect;
 }

--- a/src/main/java/com/coniverse/dangjang/domain/auth/service/OauthLoginService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/auth/service/OauthLoginService.java
@@ -29,12 +29,10 @@ public class OauthLoginService {
 	 * @since 1.0
 	 */
 	public LoginResponse login(OauthLoginRequest params) {
-
 		OAuthInfoResponse oAuthInfoResponse = oauthInfoService.request(params);
 		UserResponse user = userService.findUser(oAuthInfoResponse);
 		AuthToken authToken = authTokensGenerator.generate(user.oauthId());
-		return new LoginResponse(user.oauthId(), user.nickname(),
-			authToken.getAccessToken(), authToken.getRefreshToken(), authToken.getExpiresIn());
+		return new LoginResponse(user.nickname(), authToken.getAccessToken(), authToken.getRefreshToken(), false, false);
 	}
 
 }

--- a/src/main/java/com/coniverse/dangjang/domain/auth/service/ProductOauthInfoService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/auth/service/ProductOauthInfoService.java
@@ -6,10 +6,12 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 
 import com.coniverse.dangjang.domain.auth.dto.OauthProvider;
 import com.coniverse.dangjang.domain.auth.dto.request.OauthLoginRequest;
 import com.coniverse.dangjang.domain.auth.service.oauthInfoRequest.OAuthInfoRequestService;
+import com.coniverse.dangjang.domain.user.exception.InvalidAuthenticationException;
 import com.coniverse.dangjang.domain.user.infrastructure.OAuthInfoResponse;
 
 /**
@@ -30,12 +32,19 @@ public class ProductOauthInfoService implements OauthInfoService {
 	/**
 	 * @param params 카카오,네이버 accessToken을 받아온다.
 	 * @return OAuthInfoResponse 카카오, 네이버 사용자 정보
+	 * @Throws InvalidAuthenticationException 카카오, 네이버 사용자 정보 요청 401 에러 발생
 	 * @since 1.0.0
 	 */
 	@Override
 	public OAuthInfoResponse request(OauthLoginRequest params) {
-		OAuthInfoRequestService client = clients.get(params.getOauthProvider());
-		String accessToken = params.getOauthToken();
-		return client.requestOauthInfo(accessToken);
+		try {
+			System.out.println("params.getOauthProvider() = " + params.getOauthProvider());
+			OAuthInfoRequestService client = clients.get(params.getOauthProvider());
+			String accessToken = params.getOauthToken();
+			return client.requestOauthInfo(accessToken);
+		} catch (HttpClientErrorException.Unauthorized e) {
+			throw new InvalidAuthenticationException();
+		}
+
 	}
 }

--- a/src/main/java/com/coniverse/dangjang/domain/user/controller/SignUpController.java
+++ b/src/main/java/com/coniverse/dangjang/domain/user/controller/SignUpController.java
@@ -1,0 +1,37 @@
+package com.coniverse.dangjang.domain.user.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.coniverse.dangjang.domain.auth.dto.Response.LoginResponse;
+import com.coniverse.dangjang.domain.user.dto.SignUpRequest;
+import com.coniverse.dangjang.domain.user.service.UserService;
+import com.coniverse.dangjang.global.dto.SuccessSingleResponse;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author EVE
+ * @since 1.0
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class SignUpController {
+	private final UserService userService;
+
+	/**
+	 * @param params 회원가입에 필요한 정보를 담아온다.
+	 * @return 회원가입 후 로그인을 시도 , ResponseEntity 로그인을 성공하면, JWT TOKEN과 사용자 정보(nickname, authID)를 전달한다.
+	 * @since 1.0
+	 */
+	@PostMapping("/signUp")
+	public ResponseEntity<SuccessSingleResponse<LoginResponse>> signUp(@RequestBody SignUpRequest params) {
+		LoginResponse loginResponse = userService.signUp(params);
+		return ResponseEntity.ok().body(new SuccessSingleResponse<>(HttpStatus.OK.getReasonPhrase(), loginResponse));
+	}
+}

--- a/src/main/java/com/coniverse/dangjang/domain/user/controller/UserController.java
+++ b/src/main/java/com/coniverse/dangjang/domain/user/controller/UserController.java
@@ -1,0 +1,36 @@
+package com.coniverse.dangjang.domain.user.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.coniverse.dangjang.domain.user.dto.DuplicateNicknameResponse;
+import com.coniverse.dangjang.domain.user.service.UserService;
+import com.coniverse.dangjang.global.dto.SuccessSingleResponse;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author EVE
+ * @since 1.0
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class UserController {
+	private final UserService userService;
+
+	/**
+	 * @param nickname 확인이 필요한 닉네임을 담아온다.
+	 * @return 닉네임이 중복되지 않았으면 true, 중복된 닉네임이면 false를 담은 DuplicateNicknameResponse 객체를 반환한다.
+	 * @since 1.0
+	 */
+	@GetMapping("/duplicateNickname")
+	public ResponseEntity<SuccessSingleResponse<DuplicateNicknameResponse>> checkDuplicateNickname(@RequestParam String nickname) {
+		DuplicateNicknameResponse duplicateNicknameResponse = userService.checkDublicateNickname(nickname);
+		return ResponseEntity.ok().body(new SuccessSingleResponse<>(HttpStatus.OK.getReasonPhrase(), duplicateNicknameResponse));
+	}
+}

--- a/src/main/java/com/coniverse/dangjang/domain/user/dto/DuplicateNicknameResponse.java
+++ b/src/main/java/com/coniverse/dangjang/domain/user/dto/DuplicateNicknameResponse.java
@@ -1,0 +1,12 @@
+package com.coniverse.dangjang.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+public class DuplicateNicknameResponse {
+	private boolean isDuplicate;
+}

--- a/src/main/java/com/coniverse/dangjang/domain/user/dto/SignUpRequest.java
+++ b/src/main/java/com/coniverse/dangjang/domain/user/dto/SignUpRequest.java
@@ -1,0 +1,30 @@
+package com.coniverse.dangjang.domain.user.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import lombok.Data;
+
+/**
+ * 회원가입 Request Parm
+ *
+ * @author EVE
+ * @since 1.0
+ */
+@Data
+public class SignUpRequest {
+	private String accessToken;
+	private String provider;
+	private String nickname;
+	private Boolean gender;
+	private LocalDate birthday;
+	private int height;
+	private int weight;
+	private String activityAmount;
+	private Boolean diabetes;
+	private int diabetes_year;
+	private Boolean medicine;
+	private Boolean injection;
+	private List<String> diseases;
+
+}

--- a/src/main/java/com/coniverse/dangjang/domain/user/dto/Status.java
+++ b/src/main/java/com/coniverse/dangjang/domain/user/dto/Status.java
@@ -1,0 +1,5 @@
+package com.coniverse.dangjang.domain.user.dto;
+
+public enum Status {
+	ACTIVE, PENDING_SECESSION, SECESSION
+}

--- a/src/main/java/com/coniverse/dangjang/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/coniverse/dangjang/domain/user/dto/UserResponse.java
@@ -4,5 +4,6 @@ package com.coniverse.dangjang.domain.user.dto;
  * @author EVE
  * @since 1.0
  */
+
 public record UserResponse(String oauthId, String nickname) { //ToDo: 회원가입할 때, mapper 사용하기 , record 객체로 변경 ,  그때 DTO 이름 변경 필요
 }

--- a/src/main/java/com/coniverse/dangjang/domain/user/exception/InvalidAuthenticationException.java
+++ b/src/main/java/com/coniverse/dangjang/domain/user/exception/InvalidAuthenticationException.java
@@ -1,0 +1,17 @@
+package com.coniverse.dangjang.domain.user.exception;
+
+import com.coniverse.dangjang.global.exception.BusinessException;
+
+/**
+ * InvalidAuthenticationException
+ * 카카오, 네이버 oauth 인증이 유효하지 않을 때 발생한다.
+ * ProductOauthInfoService에서 발생
+ *
+ * @author EVE
+ * @since 1.0
+ */
+public class InvalidAuthenticationException extends BusinessException {
+	public InvalidAuthenticationException() {
+		super(401, "유효하지 않은 인증입니다.");
+	}
+}

--- a/src/main/java/com/coniverse/dangjang/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/coniverse/dangjang/domain/user/repository/UserRepository.java
@@ -1,8 +1,10 @@
 package com.coniverse.dangjang.domain.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.coniverse.dangjang.domain.user.entity.User;
+
 
 /**
  * USER Repository
@@ -19,4 +21,9 @@ public interface UserRepository extends JpaRepository<User, String> {
 	 */
 	// @Query("SELECT u FROM User u WHERE u.userId.oauthId = ?1 AND u.userId.oauthProvider = ?2")
 	// Optional<User> findByUserId(String oauthId, OauthProvider oauthProvider);
+	// @Query("SELECT u FROM User u WHERE u.userId.oauthId = ?1 AND u.userId.oauthProvider = ?2")
+	// Optional<User> findByUserId(String oauthId, OauthProvider oauthProvider);
+
+	@Query("SELECT count(u) FROM User u WHERE u.nickname = ?1 ")
+	Integer countByNickname(String nickname);
 }

--- a/src/main/java/com/coniverse/dangjang/domain/user/service/UserService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/user/service/UserService.java
@@ -4,11 +4,24 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
+import com.coniverse.dangjang.domain.auth.dto.AuthToken.AuthToken;
+import com.coniverse.dangjang.domain.auth.dto.Response.LoginResponse;
+import com.coniverse.dangjang.domain.auth.dto.request.KakaoLoginRequest;
+import com.coniverse.dangjang.domain.auth.dto.request.NaverLoginRequest;
+import com.coniverse.dangjang.domain.auth.service.OauthInfoService;
+import com.coniverse.dangjang.domain.auth.service.authToken.AuthTokensGenerator;
+import com.coniverse.dangjang.domain.user.dto.DuplicateNicknameResponse;
+import com.coniverse.dangjang.domain.user.dto.SignUpRequest;
 import com.coniverse.dangjang.domain.user.dto.UserResponse;
 import com.coniverse.dangjang.domain.user.entity.User;
+import com.coniverse.dangjang.domain.user.entity.enums.ActivityAmount;
+import com.coniverse.dangjang.domain.user.entity.enums.Gender;
+import com.coniverse.dangjang.domain.user.entity.enums.Status;
 import com.coniverse.dangjang.domain.user.exception.NonExistentUserException;
 import com.coniverse.dangjang.domain.user.infrastructure.OAuthInfoResponse;
 import com.coniverse.dangjang.domain.user.repository.UserRepository;
+
+import lombok.AllArgsConstructor;
 
 /**
  * USER Service
@@ -17,12 +30,11 @@ import com.coniverse.dangjang.domain.user.repository.UserRepository;
  * @since 1.0
  */
 @Service
+@AllArgsConstructor
 public class UserService {
 	private final UserRepository userRepository;
-
-	public UserService(UserRepository userRepository) {
-		this.userRepository = userRepository;
-	}
+	private final OauthInfoService productOauthInfoService;
+	private final AuthTokensGenerator authTokensGenerator;
 
 	/**
 	 * 기존 유저 확인
@@ -42,18 +54,87 @@ public class UserService {
 	/**
 	 * 새로운 유저 회원가입
 	 *
-	 * @param oauthInfoResponse 카카오,네이버에서 사용자 정보 조회한 데이터 (authID ,Provider)
+	 * @param signUpRequest 카카오,네이버에서 사용자 정보 조회한 데이터 (authID ,Provider)
 	 * @return 새로 가입된 유저 회원가입
 	 * @since 1.0
 	 */
 
-	public String signUp(OAuthInfoResponse oauthInfoResponse) {
+	public LoginResponse signUp(SignUpRequest signUpRequest) {
+		OAuthInfoResponse oAuthInfoResponse = null;
+		if (signUpRequest.getProvider().equals("kakao")) {
+			KakaoLoginRequest kakaoLoginRequest = new KakaoLoginRequest();
+			kakaoLoginRequest.setAccessToken(signUpRequest.getAccessToken());
+			oAuthInfoResponse = productOauthInfoService.request(kakaoLoginRequest);
+
+		} else if (signUpRequest.getProvider().equals("naver")) {
+			NaverLoginRequest naverLoginRequest = new NaverLoginRequest();
+			naverLoginRequest.setAccessToken(signUpRequest.getAccessToken());
+			oAuthInfoResponse = productOauthInfoService.request(naverLoginRequest);
+		} else {
+
+		}
+
+		Gender gender = null;
+		Float standardWeight = 0f;
+		if (signUpRequest.getGender().equals(false)) {
+			gender = Gender.M;
+			standardWeight = (float)(Math.pow(signUpRequest.getHeight() / 100, 2.0) * 22f);
+		} else {
+			gender = Gender.F;
+			standardWeight = (float)(Math.pow(signUpRequest.getHeight() / 100, 2.0) * 21f);
+		}
+
+		int recommendedCalorie = 0;
+		ActivityAmount activityAmount = ActivityAmount.LOW;
+		if (signUpRequest.getActivityAmount().equals("LOW")) {
+			activityAmount = ActivityAmount.LOW;
+			recommendedCalorie = (int)(standardWeight * 25);
+		} else if (signUpRequest.getActivityAmount().equals("MEDIUM")) {
+			activityAmount = ActivityAmount.MEDIUM;
+			recommendedCalorie = (int)(standardWeight * 30);
+		} else {
+			activityAmount = ActivityAmount.HIGH;
+			recommendedCalorie = (int)(standardWeight * 35);
+		}
+
 		User user = User.builder()
-			.oauthId(oauthInfoResponse.getUserId())
-			.nickname("nickname")
-			.oauthProvider(oauthInfoResponse.getOAuthProvider())
+			.oauthId(oAuthInfoResponse.getUserId())
+			.oauthProvider(oAuthInfoResponse.getOAuthProvider())
+			.nickname(signUpRequest.getNickname())
+			.birthday(signUpRequest.getBirthday())
+			.activityAmount(activityAmount)
+			.gender(gender)
+			.height(signUpRequest.getHeight())
+			.profileImagePath("/")
+			.status(Status.ACTIVE)
+			.recommendedCalorie(recommendedCalorie)
 			.build();
 
-		return userRepository.save(user).getOauthId();
+		return login(new UserResponse(userRepository.save(user).getOauthId(), user.getNickname()));
 	}
+
+	public LoginResponse login(UserResponse userResponse) {
+		AuthToken authToken = authTokensGenerator.generate(userResponse.oauthId());
+		return new LoginResponse(userResponse.nickname(), authToken.getAccessToken(), authToken.getRefreshToken(), false, false);
+	}
+
+	/**
+	 * 중복된 닉네임 확인
+	 *
+	 * @param nickname 확인이 필요한 닉네임
+	 * @return 중복된 닉네임이면 false, 중복되지 않았으면 true를 담은 DuplicateNicknameResponse 객체 리턴
+	 * @since 1.0
+	 */
+
+	public DuplicateNicknameResponse checkDublicateNickname(String nickname) {
+		System.out.println("nickname : " + nickname);
+		Integer countNickname = userRepository.countByNickname(nickname);
+		System.out.println("count : " + countNickname);
+		if (countNickname > 0) {
+			return new DuplicateNicknameResponse(false);
+		} else {
+			return new DuplicateNicknameResponse(true);
+		}
+	}
+
 }

--- a/src/test/java/com/coniverse/dangjang/domain/auth/service/OauthInfoServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/auth/service/OauthInfoServiceTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.web.client.HttpClientErrorException;
 
 import com.coniverse.dangjang.domain.auth.dto.request.KakaoLoginRequest;
 import com.coniverse.dangjang.domain.auth.dto.request.NaverLoginRequest;
+import com.coniverse.dangjang.domain.user.exception.InvalidAuthenticationException;
 
 @SpringBootTest
 class OauthInfoServiceTest {
@@ -20,7 +20,7 @@ class OauthInfoServiceTest {
 		kakaoLoginParams.setAccessToken("access_token");
 		kakaoLoginParams.getOauthProvider();
 		//연결이 되었을 땐 , 잘못된 accessToken으로 요청을 보냈기 때문에 401 Unauthorized 에러가 발생한다.
-		Assertions.assertThrows(HttpClientErrorException.Unauthorized.class, () -> {
+		Assertions.assertThrows(InvalidAuthenticationException.class, () -> {
 			oAuthInfoService.request(kakaoLoginParams);
 		});
 	}
@@ -31,7 +31,7 @@ class OauthInfoServiceTest {
 		naverLoginRequest.setAccessToken("access_token");
 		naverLoginRequest.getOauthProvider();
 		//연결이 되었을 땐 , 잘못된 accessToken으로 요청을 보냈기 때문에 401 Unauthorized 에러가 발생한다.
-		Assertions.assertThrows(HttpClientErrorException.Unauthorized.class, () -> {
+		Assertions.assertThrows(InvalidAuthenticationException.class, () -> {
 			oAuthInfoService.request(naverLoginRequest);
 		});
 	}

--- a/src/test/java/com/coniverse/dangjang/domain/auth/service/TestOauthInfoService.java
+++ b/src/test/java/com/coniverse/dangjang/domain/auth/service/TestOauthInfoService.java
@@ -5,11 +5,8 @@ import java.util.Date;
 import com.coniverse.dangjang.domain.auth.dto.request.OauthLoginRequest;
 import com.coniverse.dangjang.domain.user.infrastructure.KakaoInfoResponse;
 import com.coniverse.dangjang.domain.user.infrastructure.OAuthInfoResponse;
-import com.coniverse.dangjang.support.annotation.FakeBean;
+import com.coniverse.dangjang.support.FakeBean;
 
-import jakarta.transaction.Transactional;
-
-@Transactional
 @FakeBean
 public class TestOauthInfoService implements OauthInfoService {
 	@Override

--- a/src/test/java/com/coniverse/dangjang/domain/user/controller/SignUpControllerTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/user/controller/SignUpControllerTest.java
@@ -1,0 +1,45 @@
+package com.coniverse.dangjang.domain.user.controller;
+
+import static com.coniverse.dangjang.support.SimpleMockMvc.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.coniverse.dangjang.domain.auth.dto.Response.LoginResponse;
+import com.coniverse.dangjang.domain.user.dto.SignUpRequest;
+import com.coniverse.dangjang.domain.user.dto.TestRequestMethod;
+import com.coniverse.dangjang.domain.user.service.UserService;
+import com.coniverse.dangjang.support.ControllerTest;
+
+/**
+ * @author EVE
+ * @since 1.0.0
+ */
+public class SignUpControllerTest extends ControllerTest {
+	private final String URI = "/api/signUp";
+	@Autowired
+	private UserService userService;
+
+	@Test
+	void 회원가입_성공한다() throws Exception {
+		SignUpRequest signUpRequest = TestRequestMethod.getSignUpRequest();
+		LoginResponse loginResponse = new LoginResponse("test", "accessToken", "refreshToken", false, false);
+		given(userService.signUp(any())).willReturn(loginResponse);
+		String content = objectMapper.writeValueAsString(signUpRequest);
+		// when
+
+		ResultActions resultActions = post(mockMvc, URI, content);
+
+		// then
+		resultActions.andExpectAll(
+			status().isOk(),
+			jsonPath("$.message").value(HttpStatus.OK.getReasonPhrase())
+		);
+
+	}
+
+}

--- a/src/test/java/com/coniverse/dangjang/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,59 @@
+package com.coniverse.dangjang.domain.user.controller;
+
+import static com.coniverse.dangjang.support.SimpleMockMvc.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.coniverse.dangjang.domain.user.dto.SignUpRequest;
+import com.coniverse.dangjang.domain.user.dto.TestRequestMethod;
+import com.coniverse.dangjang.domain.user.service.UserService;
+import com.coniverse.dangjang.support.ControllerTest;
+
+/**
+ * @author EVE
+ * @since 1.0
+ */
+public class UserControllerTest extends ControllerTest {
+	private final String URI = "/api/duplicateNickname?nickname=";
+	@Autowired
+	private UserService userService;
+
+	@Test
+	void 중복되지_않은_닉네임_확인을_성공한다() throws Exception {
+		// given
+
+		// when
+		ResultActions resultActions = get(mockMvc, URI, "hello");
+
+		// then
+		resultActions.andExpectAll(
+			status().isOk(),
+			jsonPath("$.message").value(HttpStatus.OK.getReasonPhrase())
+		);
+
+	}
+
+	@Test
+	void 중복된_닉네임_확인을_성공한다() throws Exception {
+		// given
+		SignUpRequest signUpRequest = TestRequestMethod.getSignUpRequest();
+		signUpRequest.setActivityAmount("MEDIUM");
+		signUpRequest.setProvider("naver");
+		userService.signUp(signUpRequest);
+		// when
+		ResultActions resultActions = get(mockMvc, URI, signUpRequest.getNickname());
+
+		// then
+		resultActions.andExpectAll(
+			status().isOk(),
+			jsonPath("$.message").value(HttpStatus.OK.getReasonPhrase())
+
+		);
+
+	}
+
+}

--- a/src/test/java/com/coniverse/dangjang/domain/user/dto/TestRequestMethod.java
+++ b/src/test/java/com/coniverse/dangjang/domain/user/dto/TestRequestMethod.java
@@ -1,0 +1,29 @@
+package com.coniverse.dangjang.domain.user.dto;
+
+import java.time.LocalDate;
+
+/**
+ * 테스트에서 필요한 Request를 반환해주는 메소드를 가진 클래스
+ *
+ * @author EVE
+ * @since 1.0.0
+ */
+public class TestRequestMethod {
+	public static SignUpRequest getSignUpRequest() {
+		SignUpRequest signUpRequest = new SignUpRequest();
+		signUpRequest.setNickname("test");
+		signUpRequest.setAccessToken("287873365589");
+		signUpRequest.setGender(false);
+		signUpRequest.setInjection(true);
+		signUpRequest.setMedicine(true);
+		signUpRequest.setProvider("kakao");
+		signUpRequest.setBirthday(LocalDate.now());
+		signUpRequest.setDiabetes(true);
+		signUpRequest.setHeight(158);
+		signUpRequest.setWeight(50);
+		signUpRequest.setDiabetes_year(2);
+		signUpRequest.setActivityAmount("LOW");
+		return signUpRequest;
+	}
+
+}

--- a/src/test/java/com/coniverse/dangjang/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/user/service/UserServiceTest.java
@@ -1,0 +1,68 @@
+package com.coniverse.dangjang.domain.user.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.coniverse.dangjang.domain.auth.dto.Response.LoginResponse;
+import com.coniverse.dangjang.domain.user.dto.DuplicateNicknameResponse;
+import com.coniverse.dangjang.domain.user.dto.SignUpRequest;
+import com.coniverse.dangjang.domain.user.dto.TestRequestMethod;
+
+/**
+ * @author EVE
+ * @since 1.0.0
+ */
+@SpringBootTest
+public class UserServiceTest {
+	@Autowired
+	private UserService userService;
+
+	@Test()
+	void 새로운_유저를_추가한다_카카오() {
+		//given
+		SignUpRequest signUpRequest = TestRequestMethod.getSignUpRequest();
+
+		//when
+		LoginResponse loginResponse = userService.signUp(signUpRequest);
+		//that
+		assertThat(loginResponse).isNotNull();
+	}
+
+	@Test()
+	void 새로운_유저를_추가한다_네이버() {
+		//given
+		SignUpRequest signUpRequest = TestRequestMethod.getSignUpRequest();
+		signUpRequest.setActivityAmount("MEDIUM");
+		signUpRequest.setProvider("naver");
+		//when
+		LoginResponse loginResponse = userService.signUp(signUpRequest);
+		//that
+		assertThat(loginResponse).isNotNull();
+	}
+
+	@Test()
+	void 중복된_닉네임을_확인한다() {
+		//given
+		SignUpRequest signUpRequest = TestRequestMethod.getSignUpRequest();
+		signUpRequest.setActivityAmount("MEDIUM");
+		signUpRequest.setProvider("naver");
+		userService.signUp(signUpRequest);
+		//when
+		DuplicateNicknameResponse isDuplicated = userService.checkDublicateNickname(signUpRequest.getNickname());
+		//then
+		assertThat(isDuplicated.isDuplicate()).isEqualTo(false);
+	}
+
+	@Test()
+	void 중복되지_않은_닉네임을_확인한다() {
+		//given
+		String nickname = "nickname";
+		//when
+		DuplicateNicknameResponse isDuplicated = userService.checkDublicateNickname(nickname);
+		//then
+		assertThat(isDuplicated.isDuplicate()).isEqualTo(true);
+	}
+}

--- a/src/test/java/com/coniverse/dangjang/global/config/TestConfig.java
+++ b/src/test/java/com/coniverse/dangjang/global/config/TestConfig.java
@@ -1,0 +1,12 @@
+package com.coniverse.dangjang.global.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+
+/**
+ * @author EVE
+ * @since 1.0.0
+ */
+@TestConfiguration
+public class TestConfig {
+
+}

--- a/src/test/java/com/coniverse/dangjang/support/ControllerTest.java
+++ b/src/test/java/com/coniverse/dangjang/support/ControllerTest.java
@@ -15,6 +15,9 @@ import com.coniverse.dangjang.domain.healthMetric.service.bloodSugar.BloodSugarR
 import com.coniverse.dangjang.domain.healthMetric.util.CreatedAtUtil;
 import com.coniverse.dangjang.domain.intro.controller.IntroController;
 import com.coniverse.dangjang.domain.intro.service.IntroService;
+import com.coniverse.dangjang.domain.user.controller.SignUpController;
+import com.coniverse.dangjang.domain.user.controller.UserController;
+import com.coniverse.dangjang.domain.user.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -29,7 +32,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 	controllers = {
 		IntroController.class,
 		LoginController.class,
-		HealthMetricRegistrationController.class
+		HealthMetricRegistrationController.class,
+		LoginController.class,
+		SignUpController.class,
+		UserController.class
 	},
 	includeFilters = @ComponentScan.Filter(classes = {EnableWebSecurity.class}))
 @MockBean(JpaMetamodelMappingContext.class)
@@ -46,4 +52,7 @@ public class ControllerTest {
 	private BloodSugarRegistrationService bloodSugarService;
 	@MockBean
 	private CreatedAtUtil createdAtUtil;
+	@MockBean
+	private UserService userService;
+
 }

--- a/src/test/java/com/coniverse/dangjang/support/FakeBean.java
+++ b/src/test/java/com/coniverse/dangjang/support/FakeBean.java
@@ -1,0 +1,16 @@
+package com.coniverse.dangjang.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Primary
+@Component
+public @interface FakeBean {
+}


### PR DESCRIPTION
# Changes 📝

1. 회원가입 Controller
2. 회원가입 Service
3. 닉네임 중복여부 확인 Controller
4. 닉네임 중복여부 확인 Service 

## Details 🌼
1.    `SignUpController`   :  회원가입 Controller
SignUpRequest params에  회원가입 시 , 사용자가 입력한 정보와 oauth 토큰을 담아옵니다.

2. `UserService.signUp()`    :  회원가입 Service 메서드
- provider에 맞춰 네이버, 카카오의 oauth 토큰으로 사용자 정보를 조회합니다.
- 성별과 키에따른 표준 체중을 구하고 , 표준 체중과 하루 활동량으로 권장 칼로리를 구합니다.
- 사용자를 회원가입합니다.

3. `UserController`   :   닉네임 중복 여부 확인 Controller
- 확인이 필요한 닉네임을 RequestParam 로 받아옵니다.

4. `UserService.checkDublicateNickname`  :  닉네임 중복 여부 확인 Service
- DB에 닉네임을 조회하여 해당 닉네임이 기존에 존재하는지 확인합니다.
- 만약 존재한다면 false , 존재하지 않으면 true를 가진 DuplicateNicknameResponse 를 반환

## Check List ☑️
- [ ] 테스트 코드를 통과했다.
- [ ] merge할 브랜치의 위치를 확인했다. (main ❌)
- [ ] Assignee를 지정했다.
- [ ] Label을 지정했다.

## [Optional] Etc 추후 개선
- mapper 이용
- Controller에서 @Valid 이용해 유효성 검사 필요
