### PR TITLE
swagger - 403 error 해결

### DIFF
--- a/src/main/java/com/coniverse/dangjang/global/config/JwtFilter.java
+++ b/src/main/java/com/coniverse/dangjang/global/config/JwtFilter.java
@@ -53,7 +53,7 @@ public class JwtFilter extends OncePerRequestFilter {
 	@Override
 	protected boolean shouldNotFilter(HttpServletRequest request)
 		throws ServletException {
-		String[] excludePath = {"/api/auth/", "/api/signUp", "/api/intro/", "/api/duplicateNickname", "/api/health-metric"};
+		String[] excludePath = {"/api/auth/", "/api/signUp", "/api/intro/", "/api/duplicateNickname", "/api/health-metric", "/swagger-ui/", "/api-docs"};
 		String path = request.getRequestURI();
 		return Arrays.stream(excludePath).anyMatch(path::startsWith);
 	}

--- a/src/main/java/com/coniverse/dangjang/global/config/SecurityConfig.java
+++ b/src/main/java/com/coniverse/dangjang/global/config/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
 				.requestMatchers("/api/signUp").permitAll()
 				.requestMatchers("/api/duplicateNickname").permitAll()
 				.requestMatchers("/api/**").permitAll()
-				.requestMatchers("/swagger-ui/**").permitAll()
+				.requestMatchers("/", "/swagger-ui/**", "/api-docs/**").permitAll()
 				.anyRequest().authenticated()
 
 			);


### PR DESCRIPTION
# Changes 📝
swagger 접속 안되는 에러를 해결하였습니다.

## Details 🌼
Security와 JwtFilter에서 "/api-docs " 접근 권한이 없어서 발생하는 오류였습니다.

## Check List ☑️
- [x] 테스트 코드를 통과했다.
- [x] merge할 브랜치의 위치를 확인했다. (main ❌)
- [x] Assignee를 지정했다.
- [x] Label을 지정했다.


