### PR TITLE
운동 가이드 조회

### DIFF
--- a/src/main/java/com/coniverse/dangjang/domain/analysis/enums/Bmi.java
+++ b/src/main/java/com/coniverse/dangjang/domain/analysis/enums/Bmi.java
@@ -1,0 +1,43 @@
+package com.coniverse.dangjang.domain.analysis.enums;
+
+import java.util.Arrays;
+import java.util.function.Function;
+
+import lombok.Getter;
+
+/**
+ * BMI 분석 ENUM
+ *
+ * @author EVE
+ * @since 1.0.0
+ */
+@Getter
+public enum Bmi {
+	LOW_WEIGHT((bmi) -> (bmi < 18.5), Alert.LOW_WEIGHT),
+	NORMAL_WEIGHT((bmi) -> (18.5 <= bmi && bmi < 22.9), Alert.NORMAL_WEIGHT),
+	OVERWEIGHT((bmi) -> (22.9 <= bmi && bmi < 24.9), Alert.OVERWEIGHT),
+	LEVEL_1_OBESITY((bmi) -> (24.9 <= bmi && bmi < 29.9), Alert.LEVEL_1_OBESITY),
+	LEVEL_2_OBESITY((bmi) -> (29.9 <= bmi && bmi < 34.9), Alert.LEVEL_2_OBESITY),
+	LEVEL_3_OBESITY((bmi) -> (34.9 <= bmi), Alert.LEVEL_3_OBESITY);
+
+	private final Alert alert;
+	private final Function<Double, Boolean> alertFunction;
+
+	Bmi(Function<Double, Boolean> alertFunction, Alert alert) {
+		this.alertFunction = alertFunction;
+		this.alert = alert;
+	}
+
+	/**
+	 * BMI 수치에 따라 경보를 찾는다.
+	 *
+	 * @param bmi BMI 수치
+	 * @return 경보
+	 * @since 1.0.0
+	 */
+	public static Alert calculateBmi(Double bmi) {
+		return Arrays.stream(Bmi.values()).filter(value -> value.getAlertFunction().apply(bmi)).findFirst().get().getAlert();
+
+	}
+
+}

--- a/src/main/java/com/coniverse/dangjang/domain/analysis/enums/Bmi.java
+++ b/src/main/java/com/coniverse/dangjang/domain/analysis/enums/Bmi.java
@@ -1,7 +1,10 @@
 package com.coniverse.dangjang.domain.analysis.enums;
 
 import java.util.Arrays;
+import java.util.NoSuchElementException;
 import java.util.function.Function;
+
+import com.coniverse.dangjang.domain.analysis.exception.NonAnalyticDataException;
 
 import lombok.Getter;
 
@@ -13,7 +16,7 @@ import lombok.Getter;
  */
 @Getter
 public enum Bmi {
-	LOW_WEIGHT((bmi) -> (bmi < 18.5), Alert.LOW_WEIGHT),
+	LOW_WEIGHT((bmi) -> (0 <= bmi && bmi < 18.5), Alert.LOW_WEIGHT),
 	NORMAL_WEIGHT((bmi) -> (18.5 <= bmi && bmi < 22.9), Alert.NORMAL_WEIGHT),
 	OVERWEIGHT((bmi) -> (22.9 <= bmi && bmi < 24.9), Alert.OVERWEIGHT),
 	LEVEL_1_OBESITY((bmi) -> (24.9 <= bmi && bmi < 29.9), Alert.LEVEL_1_OBESITY),
@@ -33,10 +36,16 @@ public enum Bmi {
 	 *
 	 * @param bmi BMI 수치
 	 * @return 경보
+	 * @throws NonAnalyticDataException 분석할 수 없는 데이터일 때 발생하는 예외
 	 * @since 1.0.0
 	 */
 	public static Alert calculateBmi(Double bmi) {
-		return Arrays.stream(Bmi.values()).filter(value -> value.getAlertFunction().apply(bmi)).findFirst().get().getAlert();
+		try {
+			return Arrays.stream(Bmi.values()).filter(value -> value.getAlertFunction().apply(bmi)).findFirst().get().getAlert();
+
+		} catch (NoSuchElementException e) {
+			throw new NonAnalyticDataException();
+		}
 
 	}
 

--- a/src/main/java/com/coniverse/dangjang/domain/analysis/enums/BmiAlert.java
+++ b/src/main/java/com/coniverse/dangjang/domain/analysis/enums/BmiAlert.java
@@ -1,7 +1,6 @@
 package com.coniverse.dangjang.domain.analysis.enums;
 
 import java.util.Arrays;
-import java.util.NoSuchElementException;
 import java.util.function.Function;
 
 import com.coniverse.dangjang.domain.analysis.exception.NonAnalyticDataException;
@@ -15,7 +14,7 @@ import lombok.Getter;
  * @since 1.0.0
  */
 @Getter
-public enum Bmi {
+public enum BmiAlert {
 	LOW_WEIGHT((bmi) -> (0 <= bmi && bmi < 18.5), Alert.LOW_WEIGHT),
 	NORMAL_WEIGHT((bmi) -> (18.5 <= bmi && bmi < 22.9), Alert.NORMAL_WEIGHT),
 	OVERWEIGHT((bmi) -> (22.9 <= bmi && bmi < 24.9), Alert.OVERWEIGHT),
@@ -26,7 +25,7 @@ public enum Bmi {
 	private final Alert alert;
 	private final Function<Double, Boolean> alertFunction;
 
-	Bmi(Function<Double, Boolean> alertFunction, Alert alert) {
+	BmiAlert(Function<Double, Boolean> alertFunction, Alert alert) {
 		this.alertFunction = alertFunction;
 		this.alert = alert;
 	}
@@ -39,14 +38,13 @@ public enum Bmi {
 	 * @throws NonAnalyticDataException 분석할 수 없는 데이터일 때 발생하는 예외
 	 * @since 1.0.0
 	 */
-	public static Alert calculateBmi(Double bmi) {
-		try {
-			return Arrays.stream(Bmi.values()).filter(value -> value.getAlertFunction().apply(bmi)).findFirst().get().getAlert();
+	public static Alert findAlertByBmi(Double bmi) {
 
-		} catch (NoSuchElementException e) {
-			throw new NonAnalyticDataException();
-		}
+		return Arrays.stream(BmiAlert.values())
+			.filter(value -> value.getAlertFunction().apply(bmi))
+			.findFirst()
+			.orElseThrow(NonAnalyticDataException::new)
+			.getAlert();
 
 	}
-
 }

--- a/src/main/java/com/coniverse/dangjang/domain/analysis/enums/BmiAlert.java
+++ b/src/main/java/com/coniverse/dangjang/domain/analysis/enums/BmiAlert.java
@@ -15,12 +15,12 @@ import lombok.Getter;
  */
 @Getter
 public enum BmiAlert {
-	LOW_WEIGHT((bmi) -> (0 <= bmi && bmi < 18.5), Alert.LOW_WEIGHT),
-	NORMAL_WEIGHT((bmi) -> (18.5 <= bmi && bmi < 22.9), Alert.NORMAL_WEIGHT),
-	OVERWEIGHT((bmi) -> (22.9 <= bmi && bmi < 24.9), Alert.OVERWEIGHT),
-	LEVEL_1_OBESITY((bmi) -> (24.9 <= bmi && bmi < 29.9), Alert.LEVEL_1_OBESITY),
-	LEVEL_2_OBESITY((bmi) -> (29.9 <= bmi && bmi < 34.9), Alert.LEVEL_2_OBESITY),
-	LEVEL_3_OBESITY((bmi) -> (34.9 <= bmi), Alert.LEVEL_3_OBESITY);
+	LOW_WEIGHT(bmi -> (0 <= bmi && bmi < 18.5), Alert.LOW_WEIGHT),
+	NORMAL_WEIGHT(bmi -> (18.5 <= bmi && bmi < 22.9), Alert.NORMAL_WEIGHT),
+	OVERWEIGHT(bmi -> (22.9 <= bmi && bmi < 24.9), Alert.OVERWEIGHT),
+	LEVEL_1_OBESITY(bmi -> (24.9 <= bmi && bmi < 29.9), Alert.LEVEL_1_OBESITY),
+	LEVEL_2_OBESITY(bmi -> (29.9 <= bmi && bmi < 34.9), Alert.LEVEL_2_OBESITY),
+	LEVEL_3_OBESITY(bmi -> (34.9 <= bmi), Alert.LEVEL_3_OBESITY);
 
 	private final Alert alert;
 	private final Function<Double, Boolean> alertFunction;

--- a/src/main/java/com/coniverse/dangjang/domain/analysis/enums/ExercisePercent.java
+++ b/src/main/java/com/coniverse/dangjang/domain/analysis/enums/ExercisePercent.java
@@ -16,7 +16,7 @@ import lombok.Getter;
  */
 @Getter
 @AllArgsConstructor
-public enum ExerciseCalorie {
+public enum ExercisePercent {
 	WALK(0.9),
 	RUN(2),
 	BIKE(2.3),
@@ -30,10 +30,10 @@ public enum ExerciseCalorie {
 	 *
 	 */
 	public static double findPercentByExercise(CommonCode type) {
-		return Arrays.stream(ExerciseCalorie.values())
+		return Arrays.stream(ExercisePercent.values())
 			.filter(c -> c.name().equals(type.name()))
 			.findFirst()
-			.map(ExerciseCalorie::getPercentage)
+			.map(ExercisePercent::getPercentage)
 			.orElseThrow(EnumNonExistentException::new);
 	}
 }

--- a/src/main/java/com/coniverse/dangjang/domain/analysis/strategy/ExerciseAnalysisStrategy.java
+++ b/src/main/java/com/coniverse/dangjang/domain/analysis/strategy/ExerciseAnalysisStrategy.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 
 import com.coniverse.dangjang.domain.analysis.dto.AnalysisData;
 import com.coniverse.dangjang.domain.analysis.dto.healthMetric.ExerciseAnalysisData;
-import com.coniverse.dangjang.domain.analysis.enums.ExerciseCalorie;
+import com.coniverse.dangjang.domain.analysis.enums.ExercisePercent;
 import com.coniverse.dangjang.domain.code.enums.CommonCode;
 import com.coniverse.dangjang.domain.code.enums.GroupCode;
 import com.coniverse.dangjang.domain.healthmetric.entity.HealthMetric;
@@ -114,7 +114,7 @@ public class ExerciseAnalysisStrategy implements AnalysisStrategy {
 	 */
 	private int calculateCalorie(ExerciseAnalysisData data) {
 		String weight = healthMetricSearchService.findLastHealthMetricById(data.getOauthId(), CommonCode.MEASUREMENT).getUnit();
-		double percent = ExerciseCalorie.findPercentByExercise(data.getType());
+		double percent = ExercisePercent.findPercentByExercise(data.getType());
 		return (int)(percent * Integer.parseInt(weight) / 15 * data.unit);
 	}
 }

--- a/src/main/java/com/coniverse/dangjang/domain/analysis/strategy/WeightAnalysisStrategy.java
+++ b/src/main/java/com/coniverse/dangjang/domain/analysis/strategy/WeightAnalysisStrategy.java
@@ -53,7 +53,7 @@ public class WeightAnalysisStrategy implements AnalysisStrategy {
 	 * @return 경보
 	 * @since 1.0.0
 	 */
-	private Alert findAlert(double bmi) {
+	public Alert findAlert(double bmi) {
 		if (bmi < 18.5) {
 			return Alert.LOW_WEIGHT;
 		} else if (bmi < 22.9) {
@@ -76,7 +76,7 @@ public class WeightAnalysisStrategy implements AnalysisStrategy {
 	 * @return bmi
 	 * @since 1.0.0
 	 */
-	private double calculateBmi(int height, int weight) {
+	public double calculateBmi(int height, int weight) {
 		return weight / Math.pow(height / 100.0, 2.0);
 	}
 
@@ -89,7 +89,7 @@ public class WeightAnalysisStrategy implements AnalysisStrategy {
 	 * @return 정상 체중 대비 편차
 	 * @since 1.0.0
 	 */
-	private int calculateWeightDiff(int height, int weight, Gender gender) {
+	public int calculateWeightDiff(int height, int weight, Gender gender) {
 		int standardWeight;
 		if (gender.equals(Gender.M)) {
 			standardWeight = (int)(Math.pow(height / 100.0, 2.0) * 22);

--- a/src/main/java/com/coniverse/dangjang/domain/analysis/strategy/WeightAnalysisStrategy.java
+++ b/src/main/java/com/coniverse/dangjang/domain/analysis/strategy/WeightAnalysisStrategy.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import com.coniverse.dangjang.domain.analysis.dto.AnalysisData;
 import com.coniverse.dangjang.domain.analysis.dto.healthMetric.WeightAnalysisData;
 import com.coniverse.dangjang.domain.analysis.enums.Alert;
+import com.coniverse.dangjang.domain.analysis.enums.Bmi;
 import com.coniverse.dangjang.domain.code.enums.GroupCode;
 import com.coniverse.dangjang.domain.healthmetric.entity.HealthMetric;
 import com.coniverse.dangjang.domain.user.entity.enums.Gender;
@@ -34,7 +35,7 @@ public class WeightAnalysisStrategy implements AnalysisStrategy {
 	public AnalysisData analyze(AnalysisData analysisData) {
 		WeightAnalysisData data = (WeightAnalysisData)analysisData;
 		data.setBmi(calculateBmi(data.getHeight(), data.getUnit()));
-		Alert alert = this.findAlert(data.getBmi());
+		Alert alert = Bmi.calculateBmi(data.getBmi());
 		int weightDiff = this.calculateWeightDiff(data.getHeight(), data.getUnit(), data.getGender());
 		data.setAlert(alert);
 		data.setWeightDiff(weightDiff);
@@ -44,28 +45,6 @@ public class WeightAnalysisStrategy implements AnalysisStrategy {
 	@Override
 	public GroupCode getGroupCode() {
 		return GroupCode.WEIGHT;
-	}
-
-	/**
-	 * BMI 수치에 따라 경보를 찾는다.
-	 *
-	 * @param bmi BMI 수치
-	 * @return 경보
-	 * @since 1.0.0
-	 */
-	private Alert findAlert(double bmi) {
-		if (bmi < 18.5) {
-			return Alert.LOW_WEIGHT;
-		} else if (bmi < 22.9) {
-			return Alert.NORMAL_WEIGHT;
-		} else if (bmi < 24.9) {
-			return Alert.OVERWEIGHT;
-		} else if (bmi < 29.9) {
-			return Alert.LEVEL_1_OBESITY;
-		} else if (bmi < 34.9) {
-			return Alert.LEVEL_2_OBESITY;
-		}
-		return Alert.LEVEL_3_OBESITY;
 	}
 
 	/**
@@ -90,12 +69,7 @@ public class WeightAnalysisStrategy implements AnalysisStrategy {
 	 * @since 1.0.0
 	 */
 	private int calculateWeightDiff(int height, int weight, Gender gender) {
-		int standardWeight;
-		if (gender.equals(Gender.M)) {
-			standardWeight = (int)(Math.pow(height / 100.0, 2.0) * 22);
-		} else {
-			standardWeight = (int)(Math.pow(height / 100.0, 2.0) * 21);
-		}
+		int standardWeight = (int)(Math.pow(height / 100.0, 2.0) * gender.getPercent());
 		return weight - standardWeight;
 	}
 

--- a/src/main/java/com/coniverse/dangjang/domain/analysis/strategy/WeightAnalysisStrategy.java
+++ b/src/main/java/com/coniverse/dangjang/domain/analysis/strategy/WeightAnalysisStrategy.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component;
 import com.coniverse.dangjang.domain.analysis.dto.AnalysisData;
 import com.coniverse.dangjang.domain.analysis.dto.healthMetric.WeightAnalysisData;
 import com.coniverse.dangjang.domain.analysis.enums.Alert;
-import com.coniverse.dangjang.domain.analysis.enums.Bmi;
+import com.coniverse.dangjang.domain.analysis.enums.BmiAlert;
 import com.coniverse.dangjang.domain.code.enums.GroupCode;
 import com.coniverse.dangjang.domain.healthmetric.entity.HealthMetric;
 import com.coniverse.dangjang.domain.user.entity.enums.Gender;
@@ -35,7 +35,7 @@ public class WeightAnalysisStrategy implements AnalysisStrategy {
 	public AnalysisData analyze(AnalysisData analysisData) {
 		WeightAnalysisData data = (WeightAnalysisData)analysisData;
 		data.setBmi(calculateBmi(data.getHeight(), data.getUnit()));
-		Alert alert = Bmi.calculateBmi(data.getBmi());
+		Alert alert = BmiAlert.findAlertByBmi(data.getBmi());
 		int weightDiff = this.calculateWeightDiff(data.getHeight(), data.getUnit(), data.getGender());
 		data.setAlert(alert);
 		data.setWeightDiff(weightDiff);
@@ -69,7 +69,7 @@ public class WeightAnalysisStrategy implements AnalysisStrategy {
 	 * @since 1.0.0
 	 */
 	private int calculateWeightDiff(int height, int weight, Gender gender) {
-		int standardWeight = (int)(Math.pow(height / 100.0, 2.0) * gender.getPercent());
+		int standardWeight = (int)(Math.pow(height / 100.0, 2.0) * gender.getStandardWeightRatio());
 		return weight - standardWeight;
 	}
 

--- a/src/main/java/com/coniverse/dangjang/domain/code/enums/CommonCode.java
+++ b/src/main/java/com/coniverse/dangjang/domain/code/enums/CommonCode.java
@@ -24,7 +24,7 @@ public enum CommonCode implements EnumCode {
 	STEP_COUNT("걸음수", "step count"),
 	WALK("걷기", "walk"),
 	RUN("달리기", "run"),
-	HIKING("하이킹", "hiking"),
+	HIKING("등산", "hiking"),
 	BIKE("자전거", "bike"),
 	SWIM("수영", "swim"),
 	HEALTH("헬스", "health"),

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/controller/ExerciseGuideController.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/controller/ExerciseGuideController.java
@@ -17,12 +17,28 @@ import com.coniverse.dangjang.global.validator.ValidLocalDate;
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 운동 가이드 Controller
+ *
+ * @author EVE
+ * @since 1.0.0
+ */
+
 @RestController
 @RequiredArgsConstructor
 @Validated
 @RequestMapping("/api/guide/exercise")
 public class ExerciseGuideController {
 	private final ExerciseGuideSearchService exerciseGuideSearchService;
+
+	/**
+	 * 운동 조회
+	 *
+	 * @param date      조회하는 날짜
+	 * @param principal 유저 정보
+	 * @return 운동 가이드 응답
+	 * @since 1.0.0
+	 */
 
 	@GetMapping
 	public ResponseEntity<SuccessSingleResponse<ExerciseGuideResponse>> get(@ValidLocalDate @RequestParam String date,

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/controller/ExerciseGuideController.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/controller/ExerciseGuideController.java
@@ -1,0 +1,34 @@
+package com.coniverse.dangjang.domain.guide.exercise.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.coniverse.dangjang.domain.guide.exercise.dto.ExerciseGuideResponse;
+import com.coniverse.dangjang.domain.guide.exercise.service.ExerciseGuideSearchService;
+import com.coniverse.dangjang.global.dto.SuccessSingleResponse;
+import com.coniverse.dangjang.global.validator.ValidLocalDate;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+@RequestMapping("/api/guide/exercise")
+public class ExerciseGuideController {
+	private final ExerciseGuideSearchService exerciseGuideSearchService;
+
+	@GetMapping
+	public ResponseEntity<SuccessSingleResponse<ExerciseGuideResponse>> get(@ValidLocalDate @RequestParam String date,
+		@AuthenticationPrincipal User principal) {
+		ExerciseGuideResponse response = exerciseGuideSearchService.findGuide(principal.getUsername(), date);
+		return ResponseEntity.ok().body(new SuccessSingleResponse<>(HttpStatus.OK.getReasonPhrase(), response));
+	}
+
+}

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/document/ExerciseGuide.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/document/ExerciseGuide.java
@@ -33,11 +33,12 @@ public class ExerciseGuide {
 	private LocalDate createdAt;
 	private String content;
 	private String comparedToLastWeek;
+	private int stepsCount;
 	private List<ExerciseCalorie> exerciseCalories = new ArrayList<>();
 
 	@Builder
 	private ExerciseGuide(String oauthId, LocalDate createdAt, int needStepByTTS, String content, String comparedToLastWeek,
-		int needStepByLastWeek, List<ExerciseCalorie> exerciseCalories) {
+		int needStepByLastWeek, List<ExerciseCalorie> exerciseCalories, int stepsCount) {
 		this.oauthId = oauthId;
 		this.createdAt = createdAt;
 		this.needStepByTTS = needStepByTTS;
@@ -45,6 +46,7 @@ public class ExerciseGuide {
 		this.comparedToLastWeek = comparedToLastWeek;
 		this.needStepByLastWeek = needStepByLastWeek;
 		this.exerciseCalories = exerciseCalories;
+		this.stepsCount = stepsCount;
 	}
 
 	/**

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/document/ExerciseGuide.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/document/ExerciseGuide.java
@@ -1,6 +1,5 @@
 package com.coniverse.dangjang.domain.guide.exercise.document;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,14 +29,14 @@ public class ExerciseGuide {
 	private String oauthId;
 	private int needStepByTTS;
 	private int needStepByLastWeek;
-	private LocalDate createdAt;
+	private String createdAt;
 	private String content;
 	private String comparedToLastWeek;
 	private int stepsCount;
 	private List<ExerciseCalorie> exerciseCalories = new ArrayList<>();
 
 	@Builder
-	private ExerciseGuide(String oauthId, LocalDate createdAt, int needStepByTTS, String content, String comparedToLastWeek,
+	private ExerciseGuide(String oauthId, String createdAt, int needStepByTTS, String content, String comparedToLastWeek,
 		int needStepByLastWeek, List<ExerciseCalorie> exerciseCalories, int stepsCount) {
 		this.oauthId = oauthId;
 		this.createdAt = createdAt;

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/document/ExerciseGuide.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/document/ExerciseGuide.java
@@ -49,8 +49,12 @@ public class ExerciseGuide {
 	}
 
 	/**
-	 * 가이드 ID를 설정한다.
+	 * 걸음수와 관련된 속성들을 변경한다.
 	 *
+	 * @param needStepByTTS      만보 대비 필요한 걸음수
+	 * @param needStepByLastWeek 지난주 평균 걸음수 대비 필요한 걸음수
+	 * @param comparedToLastWeek 지난주 걸음수와 비교한 가이드
+	 * @param content            만보 대비 걸음수에 대한 가이드
 	 * @since 1.0.0
 	 */
 	public void changeAboutWalk(int needStepByTTS, int needStepByLastWeek, String comparedToLastWeek, String content) {
@@ -65,16 +69,12 @@ public class ExerciseGuide {
 	 * <p>
 	 * 기존에 존재하는 운동 칼로리를 삭제하고, 새로운 운동 칼로리를 추가한다.
 	 *
-	 * @param exerciseCalorie 운동칼로리 객체
+	 * @param updateExerciseCalorie 운동칼로리 객체
 	 * @since 1.0.0
 	 */
-	public void changeExerciseCalories(ExerciseCalorie exerciseCalorie) {
-		for (ExerciseCalorie existExerciseCalorie : exerciseCalories) {
-			if (existExerciseCalorie.type().equals(exerciseCalorie.type())) {
-				exerciseCalories.remove(existExerciseCalorie);
-				break;
-			}
-		}
-		exerciseCalories.add(exerciseCalorie);
+	public void changeExerciseCalories(ExerciseCalorie updateExerciseCalorie) {
+		exerciseCalories.stream().filter(existExerciseCalorie -> existExerciseCalorie.type().equals(updateExerciseCalorie.type()))
+			.findFirst().ifPresent(existExerciseCalorie -> exerciseCalories.remove(existExerciseCalorie));
+		exerciseCalories.add(updateExerciseCalorie);
 	}
 }

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/dto/ExerciseCalorie.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/dto/ExerciseCalorie.java
@@ -8,5 +8,5 @@ import com.coniverse.dangjang.domain.code.enums.CommonCode;
  * @author EVE
  * @since 1.0.0
  */
-public record ExerciseCalorie(CommonCode type, int calorie) {
+public record ExerciseCalorie(CommonCode type, int calorie, int exerciseTime) {
 }

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/dto/ExerciseGuideResponse.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/dto/ExerciseGuideResponse.java
@@ -1,6 +1,5 @@
 package com.coniverse.dangjang.domain.guide.exercise.dto;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import com.coniverse.dangjang.domain.guide.common.dto.GuideResponse;
@@ -11,7 +10,7 @@ import com.coniverse.dangjang.domain.guide.common.dto.GuideResponse;
  * @author EVE
  * @since 1.0.0
  */
-public record ExerciseGuideResponse(LocalDate createdAt, int needStepByTTS, int needStepByLastWeek, String comparedToLastWeek,
+public record ExerciseGuideResponse(String createdAt, int needStepByTTS, int needStepByLastWeek, String comparedToLastWeek,
 									String content, int stepsCount, List<ExerciseCalorie> exerciseCalories) implements GuideResponse {
 	@Override
 	public String type() { // TODO 수정

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/dto/ExerciseGuideResponse.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/dto/ExerciseGuideResponse.java
@@ -12,7 +12,7 @@ import com.coniverse.dangjang.domain.guide.common.dto.GuideResponse;
  * @since 1.0.0
  */
 public record ExerciseGuideResponse(LocalDate createdAt, int needStepByTTS, int needStepByLastWeek, String comparedToLastWeek,
-									String content, List<ExerciseCalorie> exerciseCalories) implements GuideResponse {
+									String content, int stepsCount, List<ExerciseCalorie> exerciseCalories) implements GuideResponse {
 	@Override
 	public String type() { // TODO 수정
 		return null;

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/dto/WalkGuideContent.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/dto/WalkGuideContent.java
@@ -12,8 +12,8 @@ import lombok.Getter;
  */
 @Getter
 public class WalkGuideContent { //TODO if-else문 다른 방법으로 해결
-	public String guideTTS;
-	public String guideLastWeek;
+	private String guideTTS;
+	private String guideLastWeek;
 
 	public WalkGuideContent(int needStepByTTS, int needStepByLastWeek) {
 		this.guideTTS = createWalkGuideContent(needStepByTTS);

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/dto/WalkGuideContent.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/dto/WalkGuideContent.java
@@ -4,8 +4,14 @@ import com.coniverse.dangjang.domain.guide.exercise.enums.GuideString;
 
 import lombok.Getter;
 
+/**
+ * 걸음수 가이드
+ *
+ * @author EVE
+ * @since 1.0.0
+ */
 @Getter
-public class WalkGuideContent {
+public class WalkGuideContent { //TODO if-else문 다른 방법으로 해결
 	public String guideTTS;
 	public String guideLastWeek;
 
@@ -24,13 +30,13 @@ public class WalkGuideContent {
 	 */
 
 	private String createWalkGuideContent(int needStepByTTS) {
+
 		if (needStepByTTS > 0) {
 			return String.format("만보보다 %d 걸음 %s", needStepByTTS, GuideString.ENOUGH.getTenThousandStepMode());
 		} else if (needStepByTTS == 0) {
 			return "와우! 만보를 걸었어요";
-		} else {
-			return String.format("만보를 걷기 위해 %d 걸음 %s", needStepByTTS, GuideString.NEED_MORE.getTenThousandStepMode());
 		}
+		return String.format("만보를 걷기 위해 %d 걸음 %s", needStepByTTS, GuideString.NEED_MORE.getTenThousandStepMode());
 
 	}
 
@@ -48,9 +54,9 @@ public class WalkGuideContent {
 				GuideString.ENOUGH.getLastWeekMode());
 		} else if (needStepByLastWeek == 0) {
 			return "지난주와 동일하게 걸었어요~ 조금 더 걸어보는건 어때요?";
-		} else {
-			return String.format("지난주 평균 걸음 수보다 %d 걸음 %s", Math.abs(needStepByLastWeek),
-				GuideString.ENOUGH.getLastWeekMode());
 		}
+		return String.format("지난주 평균 걸음 수보다 %d 걸음 %s", Math.abs(needStepByLastWeek),
+			GuideString.ENOUGH.getLastWeekMode());
+
 	}
 }

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/mapper/ExerciseGuideMapper.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/mapper/ExerciseGuideMapper.java
@@ -29,6 +29,7 @@ public interface ExerciseGuideMapper {
 	 * @since 1.0.0
 	 */
 	@Mapping(target = "exerciseCalories", ignore = true)
+	@Mapping(target = "stepsCount", source = "exerciseAnalysisData.unit")
 	ExerciseGuide toDocument(ExerciseAnalysisData exerciseAnalysisData, String content, String comparedToLastWeek);
 
 	/**

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/repository/ExerciseGuideRepository.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/repository/ExerciseGuideRepository.java
@@ -1,6 +1,5 @@
 package com.coniverse.dangjang.domain.guide.exercise.repository;
 
-import java.time.LocalDate;
 import java.util.Optional;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -22,6 +21,6 @@ public interface ExerciseGuideRepository extends MongoRepository<ExerciseGuide, 
 	 * @return 운동 가이드
 	 * @since 1.0.0
 	 */
-	
-	Optional<ExerciseGuide> findByOauthIdAndCreatedAt(String oauthId, LocalDate createdAt);
+
+	Optional<ExerciseGuide> findByOauthIdAndCreatedAt(String oauthId, String createdAt);
 }

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateService.java
@@ -49,7 +49,7 @@ public class ExerciseGuideGenerateService implements GuideGenerateService {
 		WalkGuideContent walkGuideContent = new WalkGuideContent(exerciseAnalysisData.getNeedStepByTTS(), exerciseAnalysisData.getNeedStepByLastWeek());
 
 		Optional<ExerciseGuide> exerciseGuide = exerciseGuideSearchService.findByOauthIdAndCreatedAt(exerciseAnalysisData.getOauthId(),
-			exerciseAnalysisData.getCreatedAt());
+			exerciseAnalysisData.getCreatedAt().toString());
 		// 이미 날짜에 해당하는 가이드가 존재
 		if (exerciseGuide.isPresent()) {
 			ExerciseGuide existExerciseGuide = exerciseGuide.get();
@@ -95,7 +95,7 @@ public class ExerciseGuideGenerateService implements GuideGenerateService {
 	public GuideResponse updateGuide(AnalysisData analysisData) {
 		ExerciseAnalysisData exerciseAnalysisData = (ExerciseAnalysisData)analysisData;
 		Optional<ExerciseGuide> exerciseGuide = exerciseGuideSearchService.findByOauthIdAndCreatedAt(exerciseAnalysisData.getOauthId(),
-			exerciseAnalysisData.getCreatedAt());
+			exerciseAnalysisData.getCreatedAt().toString());
 		if (exerciseGuide.isEmpty()) {
 			throw new GuideNotFoundException();
 		}

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateService.java
@@ -60,7 +60,8 @@ public class ExerciseGuideGenerateService implements GuideGenerateService {
 				return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(existExerciseGuide));
 			}
 			//운동 추가
-			ExerciseCalorie exerciseCalorie = new ExerciseCalorie(exerciseAnalysisData.getType(), exerciseAnalysisData.getCalorie());
+			ExerciseCalorie exerciseCalorie = new ExerciseCalorie(exerciseAnalysisData.getType(), exerciseAnalysisData.getCalorie(),
+				exerciseAnalysisData.getUnit());
 			existExerciseGuide.changeExerciseCalories(exerciseCalorie);
 			return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(existExerciseGuide));
 		}
@@ -73,7 +74,8 @@ public class ExerciseGuideGenerateService implements GuideGenerateService {
 
 		}
 		//새로운 운동 가이드 생성
-		ExerciseCalorie newExerciseCalorie = new ExerciseCalorie(exerciseAnalysisData.getType(), exerciseAnalysisData.getCalorie());
+		ExerciseCalorie newExerciseCalorie = new ExerciseCalorie(exerciseAnalysisData.getType(), exerciseAnalysisData.getCalorie(),
+			exerciseAnalysisData.getUnit());
 		ExerciseGuide newExerciseGuide = exerciseGuideMapper.toDocument(exerciseAnalysisData, List.of(newExerciseCalorie));
 		return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(newExerciseGuide));
 	}
@@ -105,7 +107,8 @@ public class ExerciseGuideGenerateService implements GuideGenerateService {
 			return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(updateExerciseGuide));
 		}
 		//운동 수정
-		ExerciseCalorie exerciseCalorie = new ExerciseCalorie(exerciseAnalysisData.getType(), exerciseAnalysisData.getCalorie());
+		ExerciseCalorie exerciseCalorie = new ExerciseCalorie(exerciseAnalysisData.getType(), exerciseAnalysisData.getCalorie(),
+			exerciseAnalysisData.getUnit());
 		updateExerciseGuide.changeExerciseCalories(exerciseCalorie);
 		return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(updateExerciseGuide));
 	}

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateService.java
@@ -52,7 +52,7 @@ public class ExerciseGuideGenerateService implements GuideGenerateService {
 				exerciseAnalysisData.getCreatedAt().toString());
 		} catch (GuideNotFoundException e) {
 			if (exerciseAnalysisData.getType().equals(CommonCode.STEP_COUNT)) {
-				ExerciseGuide newExerciseGuide = exerciseGuideMapper.toDocument(exerciseAnalysisData, walkGuideContent.guideTTS,
+				ExerciseGuide newExerciseGuide = exerciseGuideMapper.toDocument(exerciseAnalysisData, walkGuideContent.getGuideTTS(),
 					walkGuideContent.getGuideLastWeek());
 				return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(newExerciseGuide));
 			}

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideSearchService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideSearchService.java
@@ -22,15 +22,23 @@ public class ExerciseGuideSearchService {
 	private final ExerciseGuideRepository exerciseGuideRepository;
 	private final ExerciseGuideMapper exerciseGuideMapper;
 
+	/**
+	 * 운동 가이드를 전달한다.
+	 *
+	 * @param oauthId 유저ID
+	 * @return 운동 가이드 response
+	 * @Param createdAt 생성일
+	 * @since 1.0.0
+	 */
 	public ExerciseGuideResponse findGuide(String oauthId, String createdAt) {
 		return exerciseGuideMapper.toResponse(findByOauthIdAndCreatedAt(oauthId, createdAt));
 	}
 
 	/**
-	 * 운동 가이드를 조회한다.
+	 * 운동 가이드를 repository에서 조회한다.
 	 *
 	 * @param oauthId 유저ID
-	 * @return 운동 가이드
+	 * @return 운동 가이드 document
 	 * @Param createdAt 생성일
 	 * @since 1.0.0
 	 */

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideSearchService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideSearchService.java
@@ -1,10 +1,11 @@
 package com.coniverse.dangjang.domain.guide.exercise.service;
 
-import java.util.Optional;
-
 import org.springframework.stereotype.Service;
 
+import com.coniverse.dangjang.domain.guide.common.exception.GuideNotFoundException;
 import com.coniverse.dangjang.domain.guide.exercise.document.ExerciseGuide;
+import com.coniverse.dangjang.domain.guide.exercise.dto.ExerciseGuideResponse;
+import com.coniverse.dangjang.domain.guide.exercise.mapper.ExerciseGuideMapper;
 import com.coniverse.dangjang.domain.guide.exercise.repository.ExerciseGuideRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ExerciseGuideSearchService {
 	private final ExerciseGuideRepository exerciseGuideRepository;
+	private final ExerciseGuideMapper exerciseGuideMapper;
+
+	public ExerciseGuideResponse findGuide(String oauthId, String createdAt) {
+		return exerciseGuideMapper.toResponse(findByOauthIdAndCreatedAt(oauthId, createdAt));
+	}
 
 	/**
 	 * 운동 가이드를 조회한다.
@@ -28,8 +34,8 @@ public class ExerciseGuideSearchService {
 	 * @Param createdAt 생성일
 	 * @since 1.0.0
 	 */
-	public Optional<ExerciseGuide> findByOauthIdAndCreatedAt(String oauthId, String createdAt) {
-		return exerciseGuideRepository.findByOauthIdAndCreatedAt(oauthId, createdAt);
+	public ExerciseGuide findByOauthIdAndCreatedAt(String oauthId, String createdAt) {
+		return exerciseGuideRepository.findByOauthIdAndCreatedAt(oauthId, createdAt).orElseThrow(GuideNotFoundException::new);
 	}
 
 }

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideSearchService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideSearchService.java
@@ -1,6 +1,5 @@
 package com.coniverse.dangjang.domain.guide.exercise.service;
 
-import java.time.LocalDate;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
@@ -29,7 +28,7 @@ public class ExerciseGuideSearchService {
 	 * @Param createdAt 생성일
 	 * @since 1.0.0
 	 */
-	public Optional<ExerciseGuide> findByOauthIdAndCreatedAt(String oauthId, LocalDate createdAt) {
+	public Optional<ExerciseGuide> findByOauthIdAndCreatedAt(String oauthId, String createdAt) {
 		return exerciseGuideRepository.findByOauthIdAndCreatedAt(oauthId, createdAt);
 	}
 

--- a/src/main/java/com/coniverse/dangjang/domain/guide/weight/controller/WeightGuideController.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/weight/controller/WeightGuideController.java
@@ -1,7 +1,5 @@
 package com.coniverse.dangjang.domain.guide.weight.controller;
 
-import java.time.LocalDate;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -44,7 +42,7 @@ public class WeightGuideController {
 	@GetMapping
 	public ResponseEntity<SuccessSingleResponse<WeightGuideResponse>> get(@ValidLocalDate @RequestParam String date,
 		@AuthenticationPrincipal User principal) {
-		WeightGuideResponse response = weightGuideSearchService.findGuide(principal.getUsername(), LocalDate.parse(date));
+		WeightGuideResponse response = weightGuideSearchService.findGuide(principal.getUsername(), date);
 		return ResponseEntity.ok().body(new SuccessSingleResponse<>(HttpStatus.OK.getReasonPhrase(), response));
 	}
 }

--- a/src/main/java/com/coniverse/dangjang/domain/guide/weight/controller/WeightGuideController.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/weight/controller/WeightGuideController.java
@@ -1,0 +1,50 @@
+package com.coniverse.dangjang.domain.guide.weight.controller;
+
+import java.time.LocalDate;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.coniverse.dangjang.domain.guide.weight.dto.WeightGuideResponse;
+import com.coniverse.dangjang.domain.guide.weight.service.WeightGuideSearchService;
+import com.coniverse.dangjang.global.dto.SuccessSingleResponse;
+import com.coniverse.dangjang.global.validator.ValidLocalDate;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 체중 가이드 Controller
+ *
+ * @author EVE
+ * @since 1.0.0
+ */
+
+@RequestMapping("/api/guide/weight")
+@RequiredArgsConstructor
+@RestController
+@Validated
+public class WeightGuideController {
+	private final WeightGuideSearchService weightGuideSearchService;
+
+	/**
+	 * 날짜별 체중 가이드 조회
+	 *
+	 * @param date      조회하는 날짜
+	 * @param principal 유저 정보
+	 * @author EVE
+	 * @since 1.0.0
+	 */
+	@GetMapping
+	public ResponseEntity<SuccessSingleResponse<WeightGuideResponse>> get(@ValidLocalDate @RequestParam String date,
+		@AuthenticationPrincipal User principal) {
+		WeightGuideResponse response = weightGuideSearchService.findGuide(principal.getUsername(), LocalDate.parse(date));
+		return ResponseEntity.ok().body(new SuccessSingleResponse<>(HttpStatus.OK.getReasonPhrase(), response));
+	}
+}

--- a/src/main/java/com/coniverse/dangjang/domain/guide/weight/document/WeightGuide.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/weight/document/WeightGuide.java
@@ -1,7 +1,5 @@
 package com.coniverse.dangjang.domain.guide.weight.document;
 
-import java.time.LocalDate;
-
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import com.coniverse.dangjang.domain.analysis.enums.Alert;
@@ -30,12 +28,12 @@ public class WeightGuide {
 	private int weightDiff;
 	private double bmi;
 	private Alert alert;
-	private LocalDate createdAt;
+	private String createdAt;
 	private String content;
 	private String unit;
 
 	@Builder
-	private WeightGuide(String oauthId, CommonCode type, int weightDiff, Alert alert, LocalDate createdAt, String content, String unit, double bmi) {
+	private WeightGuide(String oauthId, CommonCode type, int weightDiff, Alert alert, String createdAt, String content, String unit, double bmi) {
 		this.oauthId = oauthId;
 		this.type = type;
 		this.weightDiff = weightDiff;
@@ -49,9 +47,9 @@ public class WeightGuide {
 	/**
 	 * 체중 속성을 변경한다.
 	 *
-	 * @param weightDiff   정상체중까지의 차이
-	 * @param alert        체중 경보
-	 * @param content 가이드 내용
+	 * @param weightDiff 정상체중까지의 차이
+	 * @param alert      체중 경보
+	 * @param content    가이드 내용
 	 * @since 1.0.0
 	 */
 	public void changeAboutWeight(int weightDiff, Alert alert, String content, double bmi) {

--- a/src/main/java/com/coniverse/dangjang/domain/guide/weight/dto/WeightGuideResponse.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/weight/dto/WeightGuideResponse.java
@@ -10,5 +10,6 @@ import com.coniverse.dangjang.domain.guide.common.dto.GuideResponse;
  * @author EVE
  * @since 1.0.0
  */
-public record WeightGuideResponse(String type, LocalDate createdAt, int weightDiff, String title, String content, double bmi) implements GuideResponse {
+public record WeightGuideResponse(String type, LocalDate createdAt, int weightDiff, String title, String content, double bmi, String unit)
+	implements GuideResponse {
 }

--- a/src/main/java/com/coniverse/dangjang/domain/guide/weight/dto/WeightGuideResponse.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/weight/dto/WeightGuideResponse.java
@@ -1,7 +1,5 @@
 package com.coniverse.dangjang.domain.guide.weight.dto;
 
-import java.time.LocalDate;
-
 import com.coniverse.dangjang.domain.guide.common.dto.GuideResponse;
 
 /**
@@ -10,6 +8,6 @@ import com.coniverse.dangjang.domain.guide.common.dto.GuideResponse;
  * @author EVE
  * @since 1.0.0
  */
-public record WeightGuideResponse(String type, LocalDate createdAt, int weightDiff, String title, String content, double bmi, String unit)
+public record WeightGuideResponse(String type, String createdAt, int weightDiff, String title, String content, double bmi, String unit)
 	implements GuideResponse {
 }

--- a/src/main/java/com/coniverse/dangjang/domain/guide/weight/repository/WeightGuideRepository.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/weight/repository/WeightGuideRepository.java
@@ -1,6 +1,7 @@
 package com.coniverse.dangjang.domain.guide.weight.repository;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
 
@@ -22,5 +23,5 @@ public interface WeightGuideRepository extends MongoRepository<WeightGuide, Stri
 	 * @return 체중 가이드
 	 * @since 1.0.0
 	 */
-	WeightGuide findByOauthIdAndCreatedAt(String oauthId, LocalDate createdAt);
+	Optional<WeightGuide> findByOauthIdAndCreatedAt(String oauthId, LocalDate createdAt);
 }

--- a/src/main/java/com/coniverse/dangjang/domain/guide/weight/repository/WeightGuideRepository.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/weight/repository/WeightGuideRepository.java
@@ -1,6 +1,5 @@
 package com.coniverse.dangjang.domain.guide.weight.repository;
 
-import java.time.LocalDate;
 import java.util.Optional;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -23,5 +22,5 @@ public interface WeightGuideRepository extends MongoRepository<WeightGuide, Stri
 	 * @return 체중 가이드
 	 * @since 1.0.0
 	 */
-	Optional<WeightGuide> findByOauthIdAndCreatedAt(String oauthId, LocalDate createdAt);
+	Optional<WeightGuide> findByOauthIdAndCreatedAt(String oauthId, String createdAt);
 }

--- a/src/main/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideGenerateService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideGenerateService.java
@@ -51,7 +51,7 @@ public class WeightGuideGenerateService implements GuideGenerateService {
 	@Override
 	public GuideResponse updateGuide(AnalysisData analysisData) {
 		WeightAnalysisData data = (WeightAnalysisData)analysisData;
-		WeightGuide weightGuide = weightGuideSearchService.findByUserIdAndCreatedAt(data.getOauthId(), data.getCreatedAt());
+		WeightGuide weightGuide = weightGuideSearchService.findByUserIdAndCreatedAt(data.getOauthId(), data.getCreatedAt().toString());
 		String content = createContent(data);
 		weightGuide.changeAboutWeight(data.getWeightDiff(), data.getAlert(), content, data.getBmi());
 		return weightMapper.toResponse(weightGuideRepository.save(weightGuide));

--- a/src/main/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideGenerateService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideGenerateService.java
@@ -51,7 +51,7 @@ public class WeightGuideGenerateService implements GuideGenerateService {
 	@Override
 	public GuideResponse updateGuide(AnalysisData analysisData) {
 		WeightAnalysisData data = (WeightAnalysisData)analysisData;
-		WeightGuide weightGuide = weightGuideSearchService.findByOauthIdAndCreatedAt(data.getOauthId(), data.getCreatedAt());
+		WeightGuide weightGuide = weightGuideSearchService.findByUserIdAndCreatedAt(data.getOauthId(), data.getCreatedAt());
 		String content = createContent(data);
 		weightGuide.changeAboutWeight(data.getWeightDiff(), data.getAlert(), content, data.getBmi());
 		return weightMapper.toResponse(weightGuideRepository.save(weightGuide));

--- a/src/main/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideSearchService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideSearchService.java
@@ -33,7 +33,7 @@ public class WeightGuideSearchService {
 	 * @since 1.0.0
 	 */
 	public WeightGuideResponse findGuide(String oauthId, LocalDate createdAt) {
-		return weightMapper.toResponse(findByOauthIdAndCreatedAt(oauthId, createdAt));
+		return weightMapper.toResponse(findByUserIdAndCreatedAt(oauthId, createdAt));
 	}
 
 	/**
@@ -44,7 +44,7 @@ public class WeightGuideSearchService {
 	 * @Param createdAt 생성일
 	 * @since 1.0.0
 	 */
-	public WeightGuide findByOauthIdAndCreatedAt(String oauthId, LocalDate createdAt) {
+	public WeightGuide findByUserIdAndCreatedAt(String oauthId, LocalDate createdAt) {
 		return weightGuideRepository.findByOauthIdAndCreatedAt(oauthId, createdAt).orElseThrow(GuideNotFoundException::new);
 	}
 

--- a/src/main/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideSearchService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideSearchService.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 
 import org.springframework.stereotype.Service;
 
+import com.coniverse.dangjang.domain.guide.common.exception.GuideNotFoundException;
 import com.coniverse.dangjang.domain.guide.weight.document.WeightGuide;
 import com.coniverse.dangjang.domain.guide.weight.dto.WeightGuideResponse;
 import com.coniverse.dangjang.domain.guide.weight.mapper.WeightMapper;
@@ -44,7 +45,7 @@ public class WeightGuideSearchService {
 	 * @since 1.0.0
 	 */
 	public WeightGuide findByOauthIdAndCreatedAt(String oauthId, LocalDate createdAt) {
-		return weightGuideRepository.findByOauthIdAndCreatedAt(oauthId, createdAt);
+		return weightGuideRepository.findByOauthIdAndCreatedAt(oauthId, createdAt).orElseThrow(GuideNotFoundException::new);
 	}
 
 }

--- a/src/main/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideSearchService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideSearchService.java
@@ -1,7 +1,5 @@
 package com.coniverse.dangjang.domain.guide.weight.service;
 
-import java.time.LocalDate;
-
 import org.springframework.stereotype.Service;
 
 import com.coniverse.dangjang.domain.guide.common.exception.GuideNotFoundException;
@@ -32,7 +30,7 @@ public class WeightGuideSearchService {
 	 * @return 운동 가이드 반응
 	 * @since 1.0.0
 	 */
-	public WeightGuideResponse findGuide(String oauthId, LocalDate createdAt) {
+	public WeightGuideResponse findGuide(String oauthId, String createdAt) {
 		return weightMapper.toResponse(findByUserIdAndCreatedAt(oauthId, createdAt));
 	}
 
@@ -44,7 +42,7 @@ public class WeightGuideSearchService {
 	 * @Param createdAt 생성일
 	 * @since 1.0.0
 	 */
-	public WeightGuide findByUserIdAndCreatedAt(String oauthId, LocalDate createdAt) {
+	public WeightGuide findByUserIdAndCreatedAt(String oauthId, String createdAt) {
 		return weightGuideRepository.findByOauthIdAndCreatedAt(oauthId, createdAt).orElseThrow(GuideNotFoundException::new);
 	}
 

--- a/src/main/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideSearchService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideSearchService.java
@@ -5,6 +5,8 @@ import java.time.LocalDate;
 import org.springframework.stereotype.Service;
 
 import com.coniverse.dangjang.domain.guide.weight.document.WeightGuide;
+import com.coniverse.dangjang.domain.guide.weight.dto.WeightGuideResponse;
+import com.coniverse.dangjang.domain.guide.weight.mapper.WeightMapper;
 import com.coniverse.dangjang.domain.guide.weight.repository.WeightGuideRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,19 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WeightGuideSearchService {
 	private final WeightGuideRepository weightGuideRepository;
+	private final WeightMapper weightMapper;
+
+	/**
+	 * 날짜별 체중 가이드를 조회한다.
+	 *
+	 * @param oauthId   유저ID
+	 * @param createdAt 생성일
+	 * @return 운동 가이드 반응
+	 * @since 1.0.0
+	 */
+	public WeightGuideResponse findGuide(String oauthId, LocalDate createdAt) {
+		return weightMapper.toResponse(findByOauthIdAndCreatedAt(oauthId, createdAt));
+	}
 
 	/**
 	 * 체중 가이드를 조회한다.
@@ -31,4 +46,5 @@ public class WeightGuideSearchService {
 	public WeightGuide findByOauthIdAndCreatedAt(String oauthId, LocalDate createdAt) {
 		return weightGuideRepository.findByOauthIdAndCreatedAt(oauthId, createdAt);
 	}
+
 }

--- a/src/main/java/com/coniverse/dangjang/domain/user/entity/enums/Gender.java
+++ b/src/main/java/com/coniverse/dangjang/domain/user/entity/enums/Gender.java
@@ -22,7 +22,7 @@ public enum Gender {
 
 	private final String title;
 	private final boolean isTrue;
-	private final int percent;
+	private final int standardWeightRatio;
 
 	public static final Map<Boolean, String> byTitle = Collections.unmodifiableMap(
 		Stream.of(values()).collect(Collectors.toMap(Gender::isTrue, Gender::name)));
@@ -31,7 +31,4 @@ public enum Gender {
 		return Gender.valueOf(byTitle.get(isTrue));
 	}
 
-	public int getPercent() {
-		return this.percent;
-	}
 }

--- a/src/main/java/com/coniverse/dangjang/domain/user/entity/enums/Gender.java
+++ b/src/main/java/com/coniverse/dangjang/domain/user/entity/enums/Gender.java
@@ -8,20 +8,30 @@ import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * User 성별
+ *
+ * @author EVE
+ * @since 1.0.0
+ */
+@Getter
 @AllArgsConstructor
 public enum Gender {
-	M("male", false),
-	F("female", true);
+	M("male", false, 22),
+	F("female", true, 21);
 
-	@Getter
 	private final String title;
-	@Getter
 	private final boolean isTrue;
+	private final int percent;
 
 	public static final Map<Boolean, String> byTitle = Collections.unmodifiableMap(
 		Stream.of(values()).collect(Collectors.toMap(Gender::isTrue, Gender::name)));
 
 	public static Gender of(Boolean isTrue) {
 		return Gender.valueOf(byTitle.get(isTrue));
+	}
+
+	public int getPercent() {
+		return this.percent;
 	}
 }

--- a/src/test/java/com/coniverse/dangjang/domain/analysis/enums/BmiAlertTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/analysis/enums/BmiAlertTest.java
@@ -11,7 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import com.coniverse.dangjang.domain.analysis.exception.NonAnalyticDataException;
 
 @SpringBootTest
-public class BmiAlertTest {
+class BmiAlertTest {
 
 	@ParameterizedTest
 	@MethodSource("com.coniverse.dangjang.fixture.AnalysisDataFixture#bmi_입력_파라미터")

--- a/src/test/java/com/coniverse/dangjang/domain/analysis/enums/BmiAlertTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/analysis/enums/BmiAlertTest.java
@@ -11,13 +11,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import com.coniverse.dangjang.domain.analysis.exception.NonAnalyticDataException;
 
 @SpringBootTest
-public class BmiTest {
+public class BmiAlertTest {
 
 	@ParameterizedTest
 	@MethodSource("com.coniverse.dangjang.fixture.AnalysisDataFixture#bmi_입력_파라미터")
 	void bmi_수치에_맞게_분석한다(double bmi, Alert alert) {
 		//when&then
-		assertThat(Bmi.calculateBmi(bmi)).isEqualTo(alert);
+		assertThat(BmiAlert.findAlertByBmi(bmi)).isEqualTo(alert);
 
 	}
 
@@ -29,7 +29,7 @@ public class BmiTest {
 		//when
 
 		//then
-		assertThrows(NonAnalyticDataException.class, () -> Bmi.calculateBmi(bmi));
+		assertThrows(NonAnalyticDataException.class, () -> BmiAlert.findAlertByBmi(bmi));
 
 	}
 }

--- a/src/test/java/com/coniverse/dangjang/domain/analysis/enums/BmiTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/analysis/enums/BmiTest.java
@@ -1,0 +1,35 @@
+package com.coniverse.dangjang.domain.analysis.enums;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.coniverse.dangjang.domain.analysis.exception.NonAnalyticDataException;
+
+@SpringBootTest
+public class BmiTest {
+
+	@ParameterizedTest
+	@MethodSource("com.coniverse.dangjang.fixture.AnalysisDataFixture#bmi_입력_파라미터")
+	void bmi_수치에_맞게_분석한다(double bmi, Alert alert) {
+		//when&then
+		assertThat(Bmi.calculateBmi(bmi)).isEqualTo(alert);
+
+	}
+
+	@ParameterizedTest
+	@ValueSource(doubles = {-1.0, -493.45})
+	void 잘못된_bmi_수치는_400에러를_반환한다(double bmi) {
+		//given
+
+		//when
+
+		//then
+		assertThrows(NonAnalyticDataException.class, () -> Bmi.calculateBmi(bmi));
+
+	}
+}

--- a/src/test/java/com/coniverse/dangjang/domain/analysis/strategy/ExerciseAnalaysisStrategyTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/analysis/strategy/ExerciseAnalaysisStrategyTest.java
@@ -1,0 +1,50 @@
+package com.coniverse.dangjang.domain.analysis.strategy;
+
+import static com.coniverse.dangjang.fixture.AnalysisDataFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.coniverse.dangjang.domain.analysis.dto.healthMetric.ExerciseAnalysisData;
+import com.coniverse.dangjang.domain.healthmetric.dto.request.HealthMetricPostRequest;
+import com.coniverse.dangjang.domain.healthmetric.entity.HealthMetric;
+import com.coniverse.dangjang.domain.healthmetric.mapper.HealthMetricMapper;
+import com.coniverse.dangjang.domain.healthmetric.service.HealthMetricSearchService;
+import com.coniverse.dangjang.domain.user.entity.User;
+
+@SpringBootTest
+public class ExerciseAnalaysisStrategyTest {
+	@Autowired
+	private ExerciseAnalysisStrategy exerciseAnalysisStrategy;
+	@Autowired
+	private HealthMetricMapper mapper;
+	@MockBean
+	private HealthMetricSearchService healthMetricSearchService;
+
+	@ParameterizedTest
+	@MethodSource("com.coniverse.dangjang.fixture.AnalysisDataFixture#운동분석_입력_파라미터")
+	void 운동_수치에_맞게_분석한다(HealthMetricPostRequest reqeust, User user, int needByTTS, int needByLastWeek, int calorie) {
+		//given
+		HealthMetric weightHelthMetric = mapper.toEntity(체중_요청("70"), user);
+		doReturn(weightHelthMetric).when(healthMetricSearchService).findLastHealthMetricById(any(), any());
+
+		HealthMetric healthMetric = mapper.toEntity(reqeust, user);
+		ExerciseAnalysisData exerciseAnalysisData = (ExerciseAnalysisData)exerciseAnalysisStrategy.createAnalysisData(healthMetric);
+
+		//when
+		ExerciseAnalysisData 운동_분석_데이터 = (ExerciseAnalysisData)exerciseAnalysisStrategy.analyze(exerciseAnalysisData);
+		//then
+		assertThat(운동_분석_데이터.getUnit()).isEqualTo(Integer.parseInt(reqeust.unit()));
+		assertThat(운동_분석_데이터.getType().getTitle()).isEqualTo(reqeust.type());
+		assertThat(운동_분석_데이터.needStepByTTS).isEqualTo(needByTTS);
+		assertThat(운동_분석_데이터.needStepByLastWeek).isEqualTo(needByLastWeek);
+		assertThat(운동_분석_데이터.calorie).isEqualTo(calorie);
+
+	}
+}

--- a/src/test/java/com/coniverse/dangjang/domain/analysis/strategy/ExerciseAnalaysisStrategyTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/analysis/strategy/ExerciseAnalaysisStrategyTest.java
@@ -14,7 +14,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import com.coniverse.dangjang.domain.analysis.dto.healthMetric.ExerciseAnalysisData;
 import com.coniverse.dangjang.domain.code.enums.CommonCode;
 import com.coniverse.dangjang.domain.healthmetric.entity.HealthMetric;
-import com.coniverse.dangjang.domain.healthmetric.mapper.HealthMetricMapper;
 import com.coniverse.dangjang.domain.healthmetric.service.HealthMetricSearchService;
 
 /**
@@ -25,8 +24,7 @@ import com.coniverse.dangjang.domain.healthmetric.service.HealthMetricSearchServ
 class ExerciseAnalaysisStrategyTest {
 	@Autowired
 	private ExerciseAnalysisStrategy exerciseAnalysisStrategy;
-	@Autowired
-	private HealthMetricMapper mapper;
+
 	@MockBean
 	private HealthMetricSearchService healthMetricSearchService;
 

--- a/src/test/java/com/coniverse/dangjang/domain/analysis/strategy/ExerciseAnalaysisStrategyTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/analysis/strategy/ExerciseAnalaysisStrategyTest.java
@@ -19,7 +19,7 @@ import com.coniverse.dangjang.domain.healthmetric.service.HealthMetricSearchServ
 import com.coniverse.dangjang.domain.user.entity.User;
 
 @SpringBootTest
-public class ExerciseAnalaysisStrategyTest {
+class ExerciseAnalaysisStrategyTest {
 	@Autowired
 	private ExerciseAnalysisStrategy exerciseAnalysisStrategy;
 	@Autowired

--- a/src/test/java/com/coniverse/dangjang/domain/analysis/strategy/ExerciseAnalaysisStrategyTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/analysis/strategy/ExerciseAnalaysisStrategyTest.java
@@ -1,6 +1,6 @@
 package com.coniverse.dangjang.domain.analysis.strategy;
 
-import static com.coniverse.dangjang.fixture.AnalysisDataFixture.*;
+import static com.coniverse.dangjang.fixture.HealthMetricFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -12,12 +12,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 import com.coniverse.dangjang.domain.analysis.dto.healthMetric.ExerciseAnalysisData;
-import com.coniverse.dangjang.domain.healthmetric.dto.request.HealthMetricPostRequest;
+import com.coniverse.dangjang.domain.code.enums.CommonCode;
 import com.coniverse.dangjang.domain.healthmetric.entity.HealthMetric;
 import com.coniverse.dangjang.domain.healthmetric.mapper.HealthMetricMapper;
 import com.coniverse.dangjang.domain.healthmetric.service.HealthMetricSearchService;
-import com.coniverse.dangjang.domain.user.entity.User;
 
+/**
+ * @author EVE
+ * @since 1.0.0
+ */
 @SpringBootTest
 class ExerciseAnalaysisStrategyTest {
 	@Autowired
@@ -27,21 +30,22 @@ class ExerciseAnalaysisStrategyTest {
 	@MockBean
 	private HealthMetricSearchService healthMetricSearchService;
 
+	private HealthMetric weightHealthMetric = 건강지표_엔티티(CommonCode.MEASUREMENT, "70");
+
 	@ParameterizedTest
 	@MethodSource("com.coniverse.dangjang.fixture.AnalysisDataFixture#운동분석_입력_파라미터")
-	void 운동_수치에_맞게_분석한다(HealthMetricPostRequest reqeust, User user, int needByTTS, int needByLastWeek, int calorie) {
+	void 운동_수치에_맞게_분석한다(HealthMetric exerciseHealthMetric, int needByTTS, int needByLastWeek, int calorie) {
 		//given
-		HealthMetric weightHelthMetric = mapper.toEntity(체중_요청("70"), user);
-		doReturn(weightHelthMetric).when(healthMetricSearchService).findLastHealthMetricById(any(), any());
 
-		HealthMetric healthMetric = mapper.toEntity(reqeust, user);
-		ExerciseAnalysisData exerciseAnalysisData = (ExerciseAnalysisData)exerciseAnalysisStrategy.createAnalysisData(healthMetric);
+		doReturn(weightHealthMetric).when(healthMetricSearchService).findLastHealthMetricById(any(), any());
+
+		ExerciseAnalysisData exerciseAnalysisData = (ExerciseAnalysisData)exerciseAnalysisStrategy.createAnalysisData(exerciseHealthMetric);
 
 		//when
 		ExerciseAnalysisData 운동_분석_데이터 = (ExerciseAnalysisData)exerciseAnalysisStrategy.analyze(exerciseAnalysisData);
 		//then
-		assertThat(운동_분석_데이터.getUnit()).isEqualTo(Integer.parseInt(reqeust.unit()));
-		assertThat(운동_분석_데이터.getType().getTitle()).isEqualTo(reqeust.type());
+		assertThat(운동_분석_데이터.getUnit()).isEqualTo(Integer.parseInt(exerciseHealthMetric.getUnit()));
+		assertThat(운동_분석_데이터.getType().getTitle()).isEqualTo(exerciseHealthMetric.getType().getTitle());
 		assertThat(운동_분석_데이터.needStepByTTS).isEqualTo(needByTTS);
 		assertThat(운동_분석_데이터.needStepByLastWeek).isEqualTo(needByLastWeek);
 		assertThat(운동_분석_데이터.calorie).isEqualTo(calorie);

--- a/src/test/java/com/coniverse/dangjang/domain/analysis/strategy/WeightAnalysisStrategyTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/analysis/strategy/WeightAnalysisStrategyTest.java
@@ -9,10 +9,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import com.coniverse.dangjang.domain.analysis.dto.healthMetric.WeightAnalysisData;
 import com.coniverse.dangjang.domain.analysis.enums.Alert;
-import com.coniverse.dangjang.domain.healthmetric.dto.request.HealthMetricPostRequest;
 import com.coniverse.dangjang.domain.healthmetric.entity.HealthMetric;
 import com.coniverse.dangjang.domain.healthmetric.mapper.HealthMetricMapper;
-import com.coniverse.dangjang.domain.user.entity.User;
 
 /**
  * @author EVE
@@ -27,18 +25,17 @@ class WeightAnalysisStrategyTest {
 
 	@ParameterizedTest
 	@MethodSource("com.coniverse.dangjang.fixture.AnalysisDataFixture#체중분석_입력_파라미터")
-	void 체중_수치에_맞게_분석한다(HealthMetricPostRequest request, User user, Alert 경보) {
+	void 체중_수치에_맞게_분석한다(HealthMetric weightHealthMetric, Alert 경보) {
 		//given
-		HealthMetric healthMetric = mapper.toEntity(request, user);
-		WeightAnalysisData AnalysisData = (WeightAnalysisData)weightAnalysisStrategy.createAnalysisData(healthMetric);
+
+		WeightAnalysisData AnalysisData = (WeightAnalysisData)weightAnalysisStrategy.createAnalysisData(weightHealthMetric);
 
 		//when
 		WeightAnalysisData weightAnalysisData = (WeightAnalysisData)weightAnalysisStrategy.analyze(AnalysisData);
-		System.out.println("경보 : " + weightAnalysisData.getAlert());
 		//then
 
-		assertThat(weightAnalysisData.getUnit()).isEqualTo(Integer.parseInt(healthMetric.getUnit()));
-		assertThat(weightAnalysisData.getType()).isEqualTo(healthMetric.getType());
+		assertThat(weightAnalysisData.getUnit()).isEqualTo(Integer.parseInt(weightHealthMetric.getUnit()));
+		assertThat(weightAnalysisData.getType()).isEqualTo(weightHealthMetric.getType());
 		assertThat(weightAnalysisData.getAlert()).isEqualTo(경보);
 
 	}

--- a/src/test/java/com/coniverse/dangjang/domain/analysis/strategy/WeightAnalysisStrategyTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/analysis/strategy/WeightAnalysisStrategyTest.java
@@ -10,7 +10,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import com.coniverse.dangjang.domain.analysis.dto.healthMetric.WeightAnalysisData;
 import com.coniverse.dangjang.domain.analysis.enums.Alert;
 import com.coniverse.dangjang.domain.healthmetric.entity.HealthMetric;
-import com.coniverse.dangjang.domain.healthmetric.mapper.HealthMetricMapper;
 
 /**
  * @author EVE
@@ -20,8 +19,6 @@ import com.coniverse.dangjang.domain.healthmetric.mapper.HealthMetricMapper;
 class WeightAnalysisStrategyTest {
 	@Autowired
 	private WeightAnalysisStrategy weightAnalysisStrategy;
-	@Autowired
-	private HealthMetricMapper mapper;
 
 	@ParameterizedTest
 	@MethodSource("com.coniverse.dangjang.fixture.AnalysisDataFixture#체중분석_입력_파라미터")

--- a/src/test/java/com/coniverse/dangjang/domain/analysis/strategy/WeightAnalysisStrategyTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/analysis/strategy/WeightAnalysisStrategyTest.java
@@ -1,0 +1,50 @@
+package com.coniverse.dangjang.domain.analysis.strategy;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.coniverse.dangjang.domain.analysis.dto.healthMetric.WeightAnalysisData;
+import com.coniverse.dangjang.domain.analysis.enums.Alert;
+import com.coniverse.dangjang.domain.healthmetric.dto.request.HealthMetricPostRequest;
+import com.coniverse.dangjang.domain.healthmetric.entity.HealthMetric;
+import com.coniverse.dangjang.domain.healthmetric.mapper.HealthMetricMapper;
+import com.coniverse.dangjang.domain.user.entity.User;
+
+/**
+ * @author EVE
+ * @since 1.0.0
+ */
+@SpringBootTest
+public class WeightAnalysisStrategyTest {
+	@Autowired
+	private WeightAnalysisStrategy weightAnalysisStrategy;
+	@Autowired
+	private HealthMetricMapper mapper;
+
+	@ParameterizedTest
+	@MethodSource("com.coniverse.dangjang.fixture.AnalysisDataFixture#체중분석_입력_파라미터")
+	void 체중_수치에_맞게_분석한다(HealthMetricPostRequest request, User user) {
+		//given
+		HealthMetric healthMetric = mapper.toEntity(request, user);
+		WeightAnalysisData AnalysisData = (WeightAnalysisData)weightAnalysisStrategy.createAnalysisData(healthMetric);
+		int 정상체중_편차 = weightAnalysisStrategy.calculateWeightDiff(user.getHeight(), Integer.parseInt(healthMetric.getUnit()), user.getGender());
+		double bmi = weightAnalysisStrategy.calculateBmi(user.getHeight(), Integer.parseInt(healthMetric.getUnit()));
+		Alert 경보 = weightAnalysisStrategy.findAlert(bmi);
+
+		//when
+		WeightAnalysisData weightAnalysisData = (WeightAnalysisData)weightAnalysisStrategy.analyze(AnalysisData);
+
+		//then
+		assertThat(weightAnalysisData.getWeightDiff()).isEqualTo(정상체중_편차);
+		assertThat(weightAnalysisData.getUnit()).isEqualTo(Integer.parseInt(healthMetric.getUnit()));
+		assertThat(weightAnalysisData.getType()).isEqualTo(healthMetric.getType());
+		assertThat(weightAnalysisData.getAlert()).isEqualTo(경보);
+		assertThat(weightAnalysisData.getBmi()).isEqualTo(bmi);
+
+	}
+
+}

--- a/src/test/java/com/coniverse/dangjang/domain/analysis/strategy/WeightAnalysisStrategyTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/analysis/strategy/WeightAnalysisStrategyTest.java
@@ -19,7 +19,7 @@ import com.coniverse.dangjang.domain.user.entity.User;
  * @since 1.0.0
  */
 @SpringBootTest
-public class WeightAnalysisStrategyTest {
+class WeightAnalysisStrategyTest {
 	@Autowired
 	private WeightAnalysisStrategy weightAnalysisStrategy;
 	@Autowired

--- a/src/test/java/com/coniverse/dangjang/domain/analysis/strategy/WeightAnalysisStrategyTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/analysis/strategy/WeightAnalysisStrategyTest.java
@@ -27,20 +27,19 @@ class WeightAnalysisStrategyTest {
 
 	@ParameterizedTest
 	@MethodSource("com.coniverse.dangjang.fixture.AnalysisDataFixture#체중분석_입력_파라미터")
-	void 체중_수치에_맞게_분석한다(HealthMetricPostRequest request, User user, int 정상체중_편차, double bmi, Alert 경보) {
+	void 체중_수치에_맞게_분석한다(HealthMetricPostRequest request, User user, Alert 경보) {
 		//given
 		HealthMetric healthMetric = mapper.toEntity(request, user);
 		WeightAnalysisData AnalysisData = (WeightAnalysisData)weightAnalysisStrategy.createAnalysisData(healthMetric);
 
 		//when
 		WeightAnalysisData weightAnalysisData = (WeightAnalysisData)weightAnalysisStrategy.analyze(AnalysisData);
-
+		System.out.println("경보 : " + weightAnalysisData.getAlert());
 		//then
-		assertThat(weightAnalysisData.getWeightDiff()).isEqualTo(정상체중_편차);
+
 		assertThat(weightAnalysisData.getUnit()).isEqualTo(Integer.parseInt(healthMetric.getUnit()));
 		assertThat(weightAnalysisData.getType()).isEqualTo(healthMetric.getType());
 		assertThat(weightAnalysisData.getAlert()).isEqualTo(경보);
-		assertThat(weightAnalysisData.getBmi()).isEqualTo(bmi);
 
 	}
 

--- a/src/test/java/com/coniverse/dangjang/domain/guide/exercise/controller/ExerciseGuideControllerTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/exercise/controller/ExerciseGuideControllerTest.java
@@ -1,0 +1,78 @@
+package com.coniverse.dangjang.domain.guide.exercise.controller;
+
+import static com.coniverse.dangjang.support.SimpleMockMvc.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import com.coniverse.dangjang.domain.code.enums.CommonCode;
+import com.coniverse.dangjang.domain.guide.exercise.dto.ExerciseCalorie;
+import com.coniverse.dangjang.domain.guide.exercise.dto.ExerciseGuideResponse;
+import com.coniverse.dangjang.domain.guide.exercise.service.ExerciseGuideSearchService;
+import com.coniverse.dangjang.support.ControllerTest;
+import com.coniverse.dangjang.support.annotation.WithDangjangUser;
+
+@WithDangjangUser
+public class ExerciseGuideControllerTest extends ControllerTest {
+	private static final String URL = "/api/guide/exercise";
+	@Autowired
+	private ExerciseGuideSearchService exerciseGuideSearchService;
+
+	private String 조회_날짜 = "2023-12-31";
+	private String 유효하지_않는_날짜 = "2023-12-35";
+
+	@Test
+	void 운동가이드_조회를_성공한다() throws Exception {
+		//given
+		int needStepByTTS = 0, needStepByWeek = 0;
+		String comparedToLastWeek = "저번주대비 걸음수 가이드입니다.";
+		String content = "만보대비 가이드입니다.";
+		int stepsCount = 0;
+		List<ExerciseCalorie> exerciseCalories = List.of(new ExerciseCalorie(CommonCode.HEALTH, 100, 60), new ExerciseCalorie(CommonCode.RUN, 200, 120));
+		ExerciseGuideResponse exerciseGuideResponse = new ExerciseGuideResponse(조회_날짜, needStepByTTS, needStepByWeek, comparedToLastWeek, content, stepsCount,
+			exerciseCalories);
+		doReturn(exerciseGuideResponse).when(exerciseGuideSearchService).findGuide(any(), any());
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("date", 조회_날짜);
+
+		//when
+		ResultActions resultActions = get(mockMvc, URL, params);
+		//then
+		resultActions.andExpectAll(
+			status().isOk(),
+			jsonPath("$.message").value("OK"),
+			jsonPath("$.data.createdAt").value(조회_날짜),
+			jsonPath("$.data.needStepByTTS").value(needStepByTTS),
+			jsonPath("$.data.needStepByLastWeek").value(needStepByWeek),
+			jsonPath("$.data.comparedToLastWeek").value(comparedToLastWeek),
+			jsonPath("$.data.content").value(content),
+			jsonPath("$.data.stepsCount").value(stepsCount),
+			jsonPath("$.data.exerciseCalories").isArray()
+		);
+	}
+
+	@Test
+	void 유효하지_않은_날짜로_운동가이드_조회를_실패한다() throws Exception {
+		//given
+
+		doReturn(null).when(exerciseGuideSearchService).findGuide(any(), any());
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("date", 유효하지_않는_날짜);
+
+		//when
+		ResultActions resultActions = get(mockMvc, URL, params);
+		//then
+		resultActions.andExpectAll(
+			status().isBadRequest(),
+			jsonPath("$.errorCode").value(400),
+			jsonPath("$.success").value(false)
+		);
+	}
+}

--- a/src/test/java/com/coniverse/dangjang/domain/guide/exercise/controller/ExerciseGuideControllerTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/exercise/controller/ExerciseGuideControllerTest.java
@@ -1,10 +1,9 @@
 package com.coniverse.dangjang.domain.guide.exercise.controller;
 
+import static com.coniverse.dangjang.fixture.GuideFixture.*;
 import static com.coniverse.dangjang.support.SimpleMockMvc.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,13 +11,15 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-import com.coniverse.dangjang.domain.code.enums.CommonCode;
-import com.coniverse.dangjang.domain.guide.exercise.dto.ExerciseCalorie;
 import com.coniverse.dangjang.domain.guide.exercise.dto.ExerciseGuideResponse;
 import com.coniverse.dangjang.domain.guide.exercise.service.ExerciseGuideSearchService;
 import com.coniverse.dangjang.support.ControllerTest;
 import com.coniverse.dangjang.support.annotation.WithDangjangUser;
 
+/**
+ * @author EVE
+ * @since 1.0.0
+ */
 @WithDangjangUser
 class ExerciseGuideControllerTest extends ControllerTest {
 	private static final String URL = "/api/guide/exercise";
@@ -28,17 +29,12 @@ class ExerciseGuideControllerTest extends ControllerTest {
 	private String 조회_날짜 = "2023-12-31";
 	private String 유효하지_않는_날짜 = "2023-12-35";
 
+	private ExerciseGuideResponse 운동_가이드_응답 = 운동_가이드_응답(조회_날짜);
+
 	@Test
 	void 운동가이드_조회를_성공한다() throws Exception {
 		//given
-		int needStepByTTS = 0, needStepByWeek = 0;
-		String comparedToLastWeek = "저번주대비 걸음수 가이드입니다.";
-		String content = "만보대비 가이드입니다.";
-		int stepsCount = 0;
-		List<ExerciseCalorie> exerciseCalories = List.of(new ExerciseCalorie(CommonCode.HEALTH, 100, 60), new ExerciseCalorie(CommonCode.RUN, 200, 120));
-		ExerciseGuideResponse exerciseGuideResponse = new ExerciseGuideResponse(조회_날짜, needStepByTTS, needStepByWeek, comparedToLastWeek, content, stepsCount,
-			exerciseCalories);
-		doReturn(exerciseGuideResponse).when(exerciseGuideSearchService).findGuide(any(), any());
+		doReturn(운동_가이드_응답).when(exerciseGuideSearchService).findGuide(any(), any());
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 		params.add("date", 조회_날짜);
 
@@ -49,11 +45,11 @@ class ExerciseGuideControllerTest extends ControllerTest {
 			status().isOk(),
 			jsonPath("$.message").value("OK"),
 			jsonPath("$.data.createdAt").value(조회_날짜),
-			jsonPath("$.data.needStepByTTS").value(needStepByTTS),
-			jsonPath("$.data.needStepByLastWeek").value(needStepByWeek),
-			jsonPath("$.data.comparedToLastWeek").value(comparedToLastWeek),
-			jsonPath("$.data.content").value(content),
-			jsonPath("$.data.stepsCount").value(stepsCount),
+			jsonPath("$.data.needStepByTTS").value(운동_가이드_응답.needStepByTTS()),
+			jsonPath("$.data.needStepByLastWeek").value(운동_가이드_응답.needStepByLastWeek()),
+			jsonPath("$.data.comparedToLastWeek").value(운동_가이드_응답.comparedToLastWeek()),
+			jsonPath("$.data.content").value(운동_가이드_응답.content()),
+			jsonPath("$.data.stepsCount").value(운동_가이드_응답.stepsCount()),
 			jsonPath("$.data.exerciseCalories").isArray()
 		);
 	}
@@ -62,7 +58,6 @@ class ExerciseGuideControllerTest extends ControllerTest {
 	void 유효하지_않은_날짜로_운동가이드_조회를_실패한다() throws Exception {
 		//given
 
-		doReturn(null).when(exerciseGuideSearchService).findGuide(any(), any());
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 		params.add("date", 유효하지_않는_날짜);
 

--- a/src/test/java/com/coniverse/dangjang/domain/guide/exercise/controller/ExerciseGuideControllerTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/exercise/controller/ExerciseGuideControllerTest.java
@@ -20,7 +20,7 @@ import com.coniverse.dangjang.support.ControllerTest;
 import com.coniverse.dangjang.support.annotation.WithDangjangUser;
 
 @WithDangjangUser
-public class ExerciseGuideControllerTest extends ControllerTest {
+class ExerciseGuideControllerTest extends ControllerTest {
 	private static final String URL = "/api/guide/exercise";
 	@Autowired
 	private ExerciseGuideSearchService exerciseGuideSearchService;

--- a/src/test/java/com/coniverse/dangjang/domain/guide/exercise/repository/ExerciseGuideRepositoryTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/exercise/repository/ExerciseGuideRepositoryTest.java
@@ -14,6 +14,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import com.coniverse.dangjang.domain.guide.exercise.document.ExerciseGuide;
 import com.coniverse.dangjang.domain.user.entity.User;
 
+/**
+ * @author EVE
+ * @since 1.0.0
+ */
 @SpringBootTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ExerciseGuideRepositoryTest {
@@ -29,10 +33,12 @@ class ExerciseGuideRepositoryTest {
 	void 운동_가이드를_성공적으로_저장한다() {
 		//given
 		exerciseGuideRepository.deleteAll();
-		//when
 		ExerciseGuide 저장된_운동가이드 = exerciseGuideRepository.save(저장하는_운동_가이드);
+
+		//when
+		ExerciseGuide 조회한_운동가이드 = exerciseGuideRepository.findById(저장된_운동가이드.getId()).get();
 		//then
-		assertThat(exerciseGuideRepository.findById(저장된_운동가이드.getId()).get().getId()).isEqualTo(저장된_운동가이드.getId());
+		assertThat(조회한_운동가이드.getId()).isEqualTo(저장된_운동가이드.getId());
 	}
 
 	@Order(200)

--- a/src/test/java/com/coniverse/dangjang/domain/guide/exercise/repository/ExerciseGuideRepositoryTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/exercise/repository/ExerciseGuideRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.coniverse.dangjang.domain.guide.exercise.repository;
+
+import static com.coniverse.dangjang.fixture.GuideFixture.*;
+import static com.coniverse.dangjang.fixture.UserFixture.*;
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.coniverse.dangjang.domain.guide.exercise.document.ExerciseGuide;
+import com.coniverse.dangjang.domain.user.entity.User;
+
+@SpringBootTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ExerciseGuideRepositoryTest {
+	@Autowired
+	private ExerciseGuideRepository exerciseGuideRepository;
+	private User 테오 = 유저_테오();
+	private String 테오_아이디 = 테오.getOauthId();
+	private String 조회_날짜 = "2023-12-31";
+	private ExerciseGuide 저장하는_운동_가이드 = 운동_가이드(테오_아이디, 조회_날짜);
+
+	@Order(100)
+	@Test
+	void 운동_가이드를_성공적으로_저장한다() {
+		//given
+		exerciseGuideRepository.deleteAll();
+		//when
+		ExerciseGuide 저장된_운동가이드 = exerciseGuideRepository.save(저장하는_운동_가이드);
+		//then
+		assertThat(exerciseGuideRepository.findById(저장된_운동가이드.getId()).get().getId()).isEqualTo(저장된_운동가이드.getId());
+	}
+
+	@Order(200)
+	@Test
+	void 운동_가이드를_성공적으로_조회한다() {
+		//given
+		//when
+		ExerciseGuide 조회하는_운동_가이드 = exerciseGuideRepository.findByOauthIdAndCreatedAt(테오_아이디, 조회_날짜).get();
+		//then
+		assertThat(조회하는_운동_가이드.getOauthId()).isEqualTo(테오_아이디);
+		assertThat(조회하는_운동_가이드.getCreatedAt()).isEqualTo(조회_날짜);
+		assertThat(조회하는_운동_가이드.getStepsCount()).isEqualTo(저장하는_운동_가이드.getStepsCount());
+		assertThat(조회하는_운동_가이드.getContent()).isEqualTo(저장하는_운동_가이드.getContent());
+		assertThat(조회하는_운동_가이드.getExerciseCalories()).isEqualTo(저장하는_운동_가이드.getExerciseCalories());
+	}
+}

--- a/src/test/java/com/coniverse/dangjang/domain/guide/exercise/repository/ExerciseGuideRepositoryTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/exercise/repository/ExerciseGuideRepositoryTest.java
@@ -16,7 +16,7 @@ import com.coniverse.dangjang.domain.user.entity.User;
 
 @SpringBootTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class ExerciseGuideRepositoryTest {
+class ExerciseGuideRepositoryTest {
 	@Autowired
 	private ExerciseGuideRepository exerciseGuideRepository;
 	private User 테오 = 유저_테오();

--- a/src/test/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateServiceTest.java
@@ -68,7 +68,7 @@ class ExerciseGuideGenerateServiceTest {
 	@ValueSource(strings = {"0", "11000", "1506", "33000", "9000"})
 	void 걸음수_조언을_성공적으로_등록한다(String unit) {
 		// given
-		var data = exerciseAnalysisStrategy.analyze(운동_분석_데이터(user, CommonCode.STEP_COUNT, unit));
+		var data = exerciseAnalysisStrategy.analyze(걸음수_분석_데이터(user, CommonCode.STEP_COUNT, unit));
 		exerciseGuideRepository.deleteAll();
 
 		// when
@@ -86,7 +86,7 @@ class ExerciseGuideGenerateServiceTest {
 	@ValueSource(strings = {"10000", "0", "3000", "200", "11000"})
 	void 걸음수_조언을_성공적으로_수정한다(String unit) {
 		// given
-		var data = exerciseAnalysisStrategy.analyze(운동_분석_데이터(user, CommonCode.STEP_COUNT, unit));
+		var data = exerciseAnalysisStrategy.analyze(걸음수_분석_데이터(user, CommonCode.STEP_COUNT, unit));
 
 		// when
 		exerciseGuideGenerateService.updateGuide(data);
@@ -101,37 +101,39 @@ class ExerciseGuideGenerateServiceTest {
 	@Order(400)
 	@ParameterizedTest
 	@MethodSource("com.coniverse.dangjang.fixture.AnalysisDataFixture#운동_시간_목록")
-	void 운동별_조언을_성공적으로_등록한다(CommonCode type, String unit) {
+	void 운동_조언을_성공적으로_등록한다(CommonCode type, String createdAt, String unit) {
 		// given
-		var data = exerciseAnalysisStrategy.analyze(운동_분석_데이터(user, type, unit));
-		Optional<ExerciseGuide> 이전_등록된_운동가이드 = exerciseGuideRepository.findByOauthIdAndCreatedAt(테오_아이디, 등록_일자);
+		var data = exerciseAnalysisStrategy.analyze(운동_분석_데이터(user, type, createdAt, unit));
+		Optional<ExerciseGuide> 이전_등록된_운동가이드 = exerciseGuideRepository.findByOauthIdAndCreatedAt(테오_아이디, createdAt);
 		List<ExerciseCalorie> exerciseCalories = new ArrayList<>();
-		int 등록되어있는_운동칼로리수 = 0;
+		int 등록되어야할_칼로리수 = 0;
+		if (이전_등록된_운동가이드.isPresent()) {
+			exerciseCalories = 이전_등록된_운동가이드.get().getExerciseCalories();
+			등록되어야할_칼로리수 = 이전_등록된_운동가이드.get().getExerciseCalories().size();
+		}
+		if (type.equals(CommonCode.STEP_COUNT) == false) {
+			exerciseCalories.add(운동_칼로리_데이터(type, Integer.parseInt(unit), 70));
+			등록되어야할_칼로리수 += 1;
+		}
 
 		//when
 		exerciseGuideGenerateService.createGuide(data);
 
 		// then
-		Optional<ExerciseGuide> 등록된_운동가이드 = exerciseGuideRepository.findByOauthIdAndCreatedAt(테오_아이디, 등록_일자);
-		if (이전_등록된_운동가이드.isPresent()) {
-			등록되어있는_운동칼로리수 = 이전_등록된_운동가이드.get().getExerciseCalories().size();
-			exerciseCalories = 이전_등록된_운동가이드.get().getExerciseCalories();
-		}
+		Optional<ExerciseGuide> 등록된_운동가이드 = exerciseGuideRepository.findByOauthIdAndCreatedAt(테오_아이디, createdAt);
 
-		exerciseCalories.add(운동_칼로리_데이터(type, Integer.parseInt(unit), 70));
-
-		assertThat(등록된_운동가이드.get().getExerciseCalories()).hasSize(등록되어있는_운동칼로리수 + 1);
+		assertThat(등록된_운동가이드.get().getExerciseCalories()).hasSize(등록되어야할_칼로리수);
 		assertThat(등록된_운동가이드.get().getExerciseCalories()).isEqualTo(exerciseCalories);
 	}
 
 	@Order(450)
 	@ParameterizedTest
 	@MethodSource("com.coniverse.dangjang.fixture.AnalysisDataFixture#운동_시간_수정목록")
-	void 운동별_조언을_성공적으로_수정한다(CommonCode type, String unit) {
+	void 운동_조언을_성공적으로_수정한다(CommonCode type, String createdAt, String unit) {
 
 		// given
 		int weight = Integer.parseInt(healthMetricSearchService.findLastHealthMetricById(user.getOauthId(), CommonCode.MEASUREMENT).getUnit());
-		var data = exerciseAnalysisStrategy.analyze(운동_분석_데이터(user, type, unit));
+		var data = exerciseAnalysisStrategy.analyze(운동_분석_데이터(user, type, createdAt, unit));
 		Optional<ExerciseGuide> 이전_등록된_운동가이드 = exerciseGuideRepository.findByOauthIdAndCreatedAt(테오_아이디, 등록_일자);
 		int 등록되어있는_운동칼로리수 = 0;
 

--- a/src/test/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateServiceTest.java
@@ -40,7 +40,7 @@ import com.coniverse.dangjang.domain.user.entity.User;
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ExerciseGuideGenerateServiceTest {
-	private final LocalDate 등록_일자 = LocalDate.of(2023, 12, 31);
+	private final String 등록_일자 = "2023-12-31";
 	@Autowired
 	private ExerciseGuideGenerateService exerciseGuideGenerateService;
 	@MockBean
@@ -58,9 +58,9 @@ class ExerciseGuideGenerateServiceTest {
 	void setUp() {
 		user = 유저_테오();
 		테오_아이디 = user.getOauthId();
-
+		LocalDate 등록_일자_LocalDate = LocalDate.parse(this.등록_일자);
 		when(healthMetricSearchService.findLastHealthMetricById(any(), any()))
-			.thenReturn(체중건강지표_엔티티(user, 등록_일자));
+			.thenReturn(체중건강지표_엔티티(user, 등록_일자_LocalDate));
 	}
 
 	@Order(200)

--- a/src/test/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateServiceTest.java
@@ -77,8 +77,8 @@ class ExerciseGuideGenerateServiceTest {
 		// then
 		Optional<ExerciseGuide> 등록된_운동가이드 = exerciseGuideRepository.findByOauthIdAndCreatedAt(테오_아이디, 등록_일자);
 		WalkGuideContent walkGuideContent = new WalkGuideContent(등록된_운동가이드.get().getNeedStepByTTS(), 등록된_운동가이드.get().getNeedStepByLastWeek());
-		assertThat(등록된_운동가이드.get().getContent()).isEqualTo(walkGuideContent.guideTTS);
-		assertThat(등록된_운동가이드.get().getComparedToLastWeek()).isEqualTo(walkGuideContent.guideLastWeek);
+		assertThat(등록된_운동가이드.get().getContent()).isEqualTo(walkGuideContent.getGuideTTS());
+		assertThat(등록된_운동가이드.get().getComparedToLastWeek()).isEqualTo(walkGuideContent.getGuideLastWeek());
 	}
 
 	@Order(250)
@@ -94,8 +94,8 @@ class ExerciseGuideGenerateServiceTest {
 		// then
 		Optional<ExerciseGuide> 등록된_운동가이드 = exerciseGuideRepository.findByOauthIdAndCreatedAt(테오_아이디, 등록_일자);
 		WalkGuideContent walkGuideContent = new WalkGuideContent(등록된_운동가이드.get().getNeedStepByTTS(), 등록된_운동가이드.get().getNeedStepByLastWeek());
-		assertThat(등록된_운동가이드.get().getContent()).isEqualTo(walkGuideContent.guideTTS);
-		assertThat(등록된_운동가이드.get().getComparedToLastWeek()).isEqualTo(walkGuideContent.guideLastWeek);
+		assertThat(등록된_운동가이드.get().getContent()).isEqualTo(walkGuideContent.getGuideTTS());
+		assertThat(등록된_운동가이드.get().getComparedToLastWeek()).isEqualTo(walkGuideContent.getGuideLastWeek());
 	}
 
 	@Order(400)

--- a/src/test/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideSearchServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideSearchServiceTest.java
@@ -17,6 +17,12 @@ import com.coniverse.dangjang.domain.guide.exercise.dto.ExerciseGuideResponse;
 import com.coniverse.dangjang.domain.guide.exercise.repository.ExerciseGuideRepository;
 import com.coniverse.dangjang.domain.user.entity.User;
 
+/**
+ * 운동 가이드 컨트롤러 테스트
+ *
+ * @author EVE
+ * @since 1.0.0
+ */
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ExerciseGuideSearchServiceTest {
@@ -40,8 +46,10 @@ class ExerciseGuideSearchServiceTest {
 	void 운동_가이드를_조회하여_Document를_반환한다() {
 		//given
 
-		//when&then
+		//when
 		ExerciseGuide exerciseGuide = exerciseGuideSearchService.findByOauthIdAndCreatedAt(테오_아이디, 조회_날짜);
+
+		// then
 		assertThat(exerciseGuide.getOauthId()).isEqualTo(테오_아이디);
 		assertThat(exerciseGuide.getCreatedAt()).isEqualTo(조회_날짜);
 		assertThat(exerciseGuide.getContent()).isEqualTo(저장한_운동_가이드.getContent());
@@ -56,11 +64,10 @@ class ExerciseGuideSearchServiceTest {
 	@Test
 	void 운동_가이드를_조회하여_Response를_반환한다() {
 		//given
-		ExerciseGuideResponse 운동_가이드_응답 = 운동_가이드_응답(테오_아이디, 조회_날짜);
 
-		//when&then
+		//when
 		ExerciseGuideResponse exerciseGuide = exerciseGuideSearchService.findGuide(테오_아이디, 조회_날짜);
-
+		//then
 		assertThat(exerciseGuide.createdAt()).isEqualTo(조회_날짜);
 		assertThat(exerciseGuide.content()).isEqualTo(저장한_운동_가이드.getContent());
 		assertThat(exerciseGuide.comparedToLastWeek()).isEqualTo(저장한_운동_가이드.getComparedToLastWeek());

--- a/src/test/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideSearchServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideSearchServiceTest.java
@@ -1,0 +1,83 @@
+package com.coniverse.dangjang.domain.guide.exercise.service;
+
+import static com.coniverse.dangjang.fixture.GuideFixture.*;
+import static com.coniverse.dangjang.fixture.UserFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.coniverse.dangjang.domain.guide.common.exception.GuideNotFoundException;
+import com.coniverse.dangjang.domain.guide.exercise.document.ExerciseGuide;
+import com.coniverse.dangjang.domain.guide.exercise.dto.ExerciseGuideResponse;
+import com.coniverse.dangjang.domain.guide.exercise.repository.ExerciseGuideRepository;
+import com.coniverse.dangjang.domain.user.entity.User;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ExerciseGuideSearchServiceTest {
+	@Autowired
+	private ExerciseGuideSearchService exerciseGuideSearchService;
+	@Autowired
+	private ExerciseGuideRepository exerciseGuideRepository;
+	private User 테오 = 유저_테오();
+	private String 테오_아이디 = 테오.getOauthId();
+	private String 조회_날짜 = "2023-12-31";
+	private String 가이드가_존재하지_않는_날짜 = "3000-12-31";
+	private ExerciseGuide 저장한_운동_가이드;
+
+	@BeforeAll
+	void setup() {
+		exerciseGuideRepository.deleteAll();
+		저장한_운동_가이드 = exerciseGuideRepository.save(운동_가이드(테오_아이디, 조회_날짜));
+	}
+
+	@Test
+	void 운동_가이드를_조회하여_Document를_반환한다() {
+		//given
+
+		//when&then
+		ExerciseGuide exerciseGuide = exerciseGuideSearchService.findByOauthIdAndCreatedAt(테오_아이디, 조회_날짜);
+		assertThat(exerciseGuide.getOauthId()).isEqualTo(테오_아이디);
+		assertThat(exerciseGuide.getCreatedAt()).isEqualTo(조회_날짜);
+		assertThat(exerciseGuide.getContent()).isEqualTo(저장한_운동_가이드.getContent());
+		assertThat(exerciseGuide.getComparedToLastWeek()).isEqualTo(저장한_운동_가이드.getComparedToLastWeek());
+		assertThat(exerciseGuide.getNeedStepByLastWeek()).isEqualTo(저장한_운동_가이드.getNeedStepByLastWeek());
+		assertThat(exerciseGuide.getStepsCount()).isEqualTo(저장한_운동_가이드.getStepsCount());
+		assertThat(exerciseGuide.getExerciseCalories()).hasSize(저장한_운동_가이드.getExerciseCalories().size());
+		assertThat(exerciseGuide.getNeedStepByTTS()).isEqualTo(저장한_운동_가이드.getNeedStepByTTS());
+
+	}
+
+	@Test
+	void 운동_가이드를_조회하여_Response를_반환한다() {
+		//given
+		ExerciseGuideResponse 운동_가이드_응답 = 운동_가이드_응답(테오_아이디, 조회_날짜);
+
+		//when&then
+		ExerciseGuideResponse exerciseGuide = exerciseGuideSearchService.findGuide(테오_아이디, 조회_날짜);
+
+		assertThat(exerciseGuide.createdAt()).isEqualTo(조회_날짜);
+		assertThat(exerciseGuide.content()).isEqualTo(저장한_운동_가이드.getContent());
+		assertThat(exerciseGuide.comparedToLastWeek()).isEqualTo(저장한_운동_가이드.getComparedToLastWeek());
+		assertThat(exerciseGuide.needStepByLastWeek()).isEqualTo(저장한_운동_가이드.getNeedStepByLastWeek());
+		assertThat(exerciseGuide.stepsCount()).isEqualTo(저장한_운동_가이드.getStepsCount());
+		assertThat(exerciseGuide.exerciseCalories()).hasSize(저장한_운동_가이드.getExerciseCalories().size());
+		assertThat(exerciseGuide.needStepByTTS()).isEqualTo(저장한_운동_가이드.getNeedStepByTTS());
+
+	}
+
+	@Test
+	void 유효하지_않는_날짜로_조회하여_예외를_발생시킨다() {
+		//given
+
+		//when&then
+		assertThrows(GuideNotFoundException.class, () -> {
+			exerciseGuideSearchService.findGuide(테오_아이디, 가이드가_존재하지_않는_날짜);
+		});
+	}
+}

--- a/src/test/java/com/coniverse/dangjang/domain/guide/weight/controller/WeightGuideControllerTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/weight/controller/WeightGuideControllerTest.java
@@ -27,7 +27,7 @@ class WeightGuideControllerTest extends ControllerTest {
 	private WeightGuideSearchService weightGuideSearchService;
 	public static final String URL = "/api/guide/weight";
 	private static final String createdAt = "2023-12-31";
-	private static final String 등록되지_않은_날짜 = "3000-12-31";
+	private static final String 등록되지_않은_날짜 = "3000-12-33";
 
 	@Test
 	void 체중_조회를_성공한다() throws Exception {

--- a/src/test/java/com/coniverse/dangjang/domain/guide/weight/controller/WeightGuideControllerTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/weight/controller/WeightGuideControllerTest.java
@@ -1,0 +1,72 @@
+package com.coniverse.dangjang.domain.guide.weight.controller;
+
+import static com.coniverse.dangjang.fixture.GuideFixture.*;
+import static com.coniverse.dangjang.support.SimpleMockMvc.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import com.coniverse.dangjang.domain.guide.weight.dto.WeightGuideResponse;
+import com.coniverse.dangjang.domain.guide.weight.service.WeightGuideSearchService;
+import com.coniverse.dangjang.support.ControllerTest;
+import com.coniverse.dangjang.support.annotation.WithDangjangUser;
+
+/**
+ * @author EVE
+ * @since 1.0.0
+ */
+@WithDangjangUser
+public class WeightGuideControllerTest extends ControllerTest {
+	@Autowired
+	private WeightGuideSearchService weightGuideSearchService;
+	public static final String URL = "/api/guide/weight";
+	private static final String createdAt = "2023-12-31";
+
+	@Test
+	void 체중_조회를_성공한다() throws Exception {
+		// given
+		WeightGuideResponse response = 체중_가이드_응답(createdAt);
+		doReturn(response).when(weightGuideSearchService).findGuide(any(), any());
+		// when
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("date", "2023-12-31");
+
+		// when
+		ResultActions resultActions = get(mockMvc, URL, params);
+		// then
+		resultActions.andExpectAll(
+			status().isOk(),
+			jsonPath("$.message").value(HttpStatus.OK.getReasonPhrase()),
+			jsonPath("$.data.createdAt").value(createdAt),
+			jsonPath("$.data.title").value(response.title()),
+			jsonPath("$.data.content").value(response.content()),
+			jsonPath("$.data.weightDiff").value(response.weightDiff()),
+			jsonPath("$.data.bmi").value(response.bmi()),
+			jsonPath("$.data.unit").value(response.unit())
+		);
+	}
+
+	@Test
+	void 유효하지_않는_날짜로_체중_조회를_실패한다() throws Exception {
+		// given
+		WeightGuideResponse response = 체중_가이드_응답(createdAt);
+		doReturn(null).when(weightGuideSearchService).findGuide(any(), any());
+		// when
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("date", "3000-12-33");
+
+		// when
+		ResultActions resultActions = get(mockMvc, URL, params);
+		// then
+		resultActions.andExpectAll(
+			status().isBadRequest(),
+			jsonPath("$.errorCode").value(400)
+		);
+	}
+}

--- a/src/test/java/com/coniverse/dangjang/domain/guide/weight/controller/WeightGuideControllerTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/weight/controller/WeightGuideControllerTest.java
@@ -27,6 +27,7 @@ class WeightGuideControllerTest extends ControllerTest {
 	private WeightGuideSearchService weightGuideSearchService;
 	public static final String URL = "/api/guide/weight";
 	private static final String createdAt = "2023-12-31";
+	private static final String 등록되지_않은_날짜 = "3000-12-31";
 
 	@Test
 	void 체중_조회를_성공한다() throws Exception {
@@ -59,7 +60,7 @@ class WeightGuideControllerTest extends ControllerTest {
 		doReturn(null).when(weightGuideSearchService).findGuide(any(), any());
 		// when
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-		params.add("date", "3000-12-33");
+		params.add("date", 등록되지_않은_날짜);
 
 		// when
 		ResultActions resultActions = get(mockMvc, URL, params);

--- a/src/test/java/com/coniverse/dangjang/domain/guide/weight/controller/WeightGuideControllerTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/weight/controller/WeightGuideControllerTest.java
@@ -22,7 +22,7 @@ import com.coniverse.dangjang.support.annotation.WithDangjangUser;
  * @since 1.0.0
  */
 @WithDangjangUser
-public class WeightGuideControllerTest extends ControllerTest {
+class WeightGuideControllerTest extends ControllerTest {
 	@Autowired
 	private WeightGuideSearchService weightGuideSearchService;
 	public static final String URL = "/api/guide/weight";

--- a/src/test/java/com/coniverse/dangjang/domain/guide/weight/repository/WeightGuideRepositoryTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/weight/repository/WeightGuideRepositoryTest.java
@@ -18,7 +18,7 @@ import com.coniverse.dangjang.support.annotation.MongoRepositoryTest;
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @MongoRepositoryTest
-public class WeightGuideRepositoryTest {
+class WeightGuideRepositoryTest {
 	@Autowired
 	private WeightGuideRepository weightGuideRepository;
 	private static final String 아이디 = "11111111";

--- a/src/test/java/com/coniverse/dangjang/domain/guide/weight/repository/WeightGuideRepositoryTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/weight/repository/WeightGuideRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.coniverse.dangjang.domain.guide.weight.repository;
+
+import static com.coniverse.dangjang.fixture.GuideFixture.*;
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.coniverse.dangjang.domain.guide.weight.document.WeightGuide;
+import com.coniverse.dangjang.support.annotation.MongoRepositoryTest;
+
+/**
+ * @author EVE
+ * @since 1.0.0
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@MongoRepositoryTest
+public class WeightGuideRepositoryTest {
+	@Autowired
+	private WeightGuideRepository weightGuideRepository;
+	private static final String 아이디 = "11111111";
+	private static final String createdAt = "2023-12-31";
+	private static WeightGuide 체중_가이드;
+
+	@Order(100)
+	@Test
+	void 체중_가이드를_저장한다() {
+		// when
+		weightGuideRepository.deleteAll();
+		체중_가이드 = weightGuideRepository.save(체중_가이드(아이디, createdAt));
+
+		// then
+		WeightGuide 찾은_체중_가이드 = weightGuideRepository.findByOauthIdAndCreatedAt(체중_가이드.getOauthId(), 체중_가이드.getCreatedAt()).orElseThrow();
+		assertThat(찾은_체중_가이드.getOauthId()).isEqualTo(아이디);
+		assertThat(찾은_체중_가이드.getCreatedAt()).isEqualTo(createdAt);
+	}
+
+	@Order(200)
+	@Test
+	void 체중_가이드를_조회한다() {
+		// when
+
+		// then
+		WeightGuide 찾은_체중_가이드 = weightGuideRepository.findByOauthIdAndCreatedAt(체중_가이드.getOauthId(), 체중_가이드.getCreatedAt()).orElseThrow();
+		assertThat(찾은_체중_가이드.getOauthId()).isEqualTo(아이디);
+		assertThat(찾은_체중_가이드.getCreatedAt()).isEqualTo(createdAt);
+	}
+}

--- a/src/test/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideGenerateServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideGenerateServiceTest.java
@@ -19,9 +19,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import com.coniverse.dangjang.domain.analysis.dto.healthMetric.WeightAnalysisData;
 import com.coniverse.dangjang.domain.analysis.strategy.WeightAnalysisStrategy;
+import com.coniverse.dangjang.domain.guide.common.exception.GuideNotFoundException;
 import com.coniverse.dangjang.domain.guide.weight.document.WeightGuide;
 import com.coniverse.dangjang.domain.guide.weight.repository.WeightGuideRepository;
-import com.coniverse.dangjang.domain.guide.weight.service.WeightGuideGenerateService;
 import com.coniverse.dangjang.domain.user.repository.UserRepository;
 
 /**
@@ -60,7 +60,7 @@ class WeightGuideGenerateServiceTest {
 		// when
 		weightGuideGenerateService.createGuide(data);
 		// then
-		WeightGuide 등록된_건강지표 = weightGuideRepository.findByOauthIdAndCreatedAt(테오_아이디, 등록_일자);
+		WeightGuide 등록된_건강지표 = weightGuideRepository.findByOauthIdAndCreatedAt(테오_아이디, 등록_일자).orElseThrow(GuideNotFoundException::new);
 		assertThat(등록된_건강지표.getContent()).isEqualTo(weightGuideGenerateService.createContent((WeightAnalysisData)data));
 	}
 
@@ -74,7 +74,7 @@ class WeightGuideGenerateServiceTest {
 		weightGuideGenerateService.updateGuide(data);
 
 		// then
-		WeightGuide 등록된_건강지표 = weightGuideRepository.findByOauthIdAndCreatedAt(테오_아이디, 등록_일자);
+		WeightGuide 등록된_건강지표 = weightGuideRepository.findByOauthIdAndCreatedAt(테오_아이디, 등록_일자).orElseThrow(GuideNotFoundException::new);
 		assertThat(등록된_건강지표.getContent()).isEqualTo(weightGuideGenerateService.createContent((WeightAnalysisData)data));
 	}
 }

--- a/src/test/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideGenerateServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideGenerateServiceTest.java
@@ -4,8 +4,6 @@ import static com.coniverse.dangjang.fixture.AnalysisDataFixture.*;
 import static com.coniverse.dangjang.fixture.UserFixture.*;
 import static org.assertj.core.api.Assertions.*;
 
-import java.time.LocalDate;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -32,7 +30,7 @@ import com.coniverse.dangjang.domain.user.repository.UserRepository;
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class WeightGuideGenerateServiceTest {
-	private final LocalDate 등록_일자 = LocalDate.of(2023, 12, 31);
+	private final String 등록_일자 = "2023-12-31";
 	@Autowired
 	private WeightGuideGenerateService weightGuideGenerateService;
 	@Autowired

--- a/src/test/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideSearchServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideSearchServiceTest.java
@@ -73,7 +73,7 @@ class WeightGuideSearchServiceTest {
 	}
 
 	@Test
-	void 체중_가이드를_조회히여_Document를_반환한다() {
+	void 체중_가이드를_조회하여_Document를_반환한다() {
 		// given
 
 		// when

--- a/src/test/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideSearchServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideSearchServiceTest.java
@@ -5,8 +5,6 @@ import static com.coniverse.dangjang.fixture.UserFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.time.LocalDate;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -49,7 +47,7 @@ class WeightGuideSearchServiceTest {
 		// given
 		WeightGuideResponse 저장된_체중_가이드_응답 = weightMapper.toResponse(저장된_체중_가이드);
 		// when
-		WeightGuideResponse weightGuideResponse = weightGuideSearchService.findGuide(테오_아이디, LocalDate.parse(생성일자));
+		WeightGuideResponse weightGuideResponse = weightGuideSearchService.findGuide(테오_아이디, 생성일자);
 		// then
 		assertAll(
 			() -> assertThat(weightGuideResponse.bmi()).isEqualTo(저장된_체중_가이드_응답.bmi()),
@@ -65,7 +63,7 @@ class WeightGuideSearchServiceTest {
 	@Test
 	void 존재하지_않는_날짜의_가이드조회를_실패한다() {
 		// given
-		LocalDate 존재하지_않는_날짜 = LocalDate.parse("3000-12-30");
+		String 존재하지_않는_날짜 = "3000-12-30";
 
 		// when
 		// then
@@ -79,7 +77,7 @@ class WeightGuideSearchServiceTest {
 		// given
 
 		// when
-		WeightGuide weightGuideResponse = weightGuideSearchService.findByUserIdAndCreatedAt(테오_아이디, LocalDate.parse(생성일자));
+		WeightGuide weightGuideResponse = weightGuideSearchService.findByUserIdAndCreatedAt(테오_아이디, 생성일자);
 
 		// then
 		assertAll(
@@ -95,7 +93,7 @@ class WeightGuideSearchServiceTest {
 	@Test
 	void 존재하지_않는_가이드조회를_실패한다() {
 		// given
-		LocalDate 존재하지_않는_날짜 = LocalDate.parse("3000-12-30");
+		String 존재하지_않는_날짜 = "3000-12-30";
 		// when
 
 		// then

--- a/src/test/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideSearchServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideSearchServiceTest.java
@@ -25,7 +25,7 @@ import com.coniverse.dangjang.domain.guide.weight.repository.WeightGuideReposito
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest
-public class WeightGuideSearchServiceTest {
+class WeightGuideSearchServiceTest {
 	@Autowired
 	private WeightGuideRepository weightGuideRepository;
 	@Autowired
@@ -65,12 +65,12 @@ public class WeightGuideSearchServiceTest {
 	@Test
 	void 존재하지_않는_날짜의_가이드조회를_실패한다() {
 		// given
+		LocalDate 존재하지_않는_날짜 = LocalDate.parse("3000-12-30");
 
 		// when
-
 		// then
 		assertThrows(GuideNotFoundException.class, () -> {
-			weightGuideSearchService.findGuide(테오_아이디, LocalDate.parse("3000-12-30"));
+			weightGuideSearchService.findGuide(테오_아이디, 존재하지_않는_날짜);
 		});
 	}
 
@@ -95,12 +95,12 @@ public class WeightGuideSearchServiceTest {
 	@Test
 	void 존재하지_않는_가이드조회를_실패한다() {
 		// given
-
+		LocalDate 존재하지_않는_날짜 = LocalDate.parse("3000-12-30");
 		// when
 
 		// then
 		assertThrows(GuideNotFoundException.class, () -> {
-			weightGuideSearchService.findByUserIdAndCreatedAt(테오_아이디, LocalDate.parse("3000-12-30"));
+			weightGuideSearchService.findByUserIdAndCreatedAt(테오_아이디, 존재하지_않는_날짜);
 		});
 	}
 }

--- a/src/test/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideSearchServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideSearchServiceTest.java
@@ -1,0 +1,78 @@
+package com.coniverse.dangjang.domain.guide.weight.service;
+
+import static com.coniverse.dangjang.fixture.GuideFixture.*;
+import static com.coniverse.dangjang.fixture.UserFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.coniverse.dangjang.domain.guide.common.exception.GuideNotFoundException;
+import com.coniverse.dangjang.domain.guide.weight.document.WeightGuide;
+import com.coniverse.dangjang.domain.guide.weight.dto.WeightGuideResponse;
+import com.coniverse.dangjang.domain.guide.weight.mapper.WeightMapper;
+import com.coniverse.dangjang.domain.guide.weight.repository.WeightGuideRepository;
+import com.coniverse.dangjang.support.annotation.WithDangjangUser;
+
+/**
+ * @author EVE
+ * @since 1.0.0
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest
+@WithDangjangUser
+public class WeightGuideSearchServiceTest {
+	@Autowired
+	private WeightGuideRepository weightGuideRepository;
+	@Autowired
+	private WeightGuideSearchService weightGuideSearchService;
+	@Autowired
+	private WeightMapper weightMapper;
+	private String 테오_아이디 = 유저_테오().getOauthId();
+	private String 생성일자 = "2023-12-31";
+	private WeightGuide 저장된_체중_가이드;
+
+	@BeforeAll
+	void setUp() {
+		저장된_체중_가이드 = 체중_가이드(테오_아이디, 생성일자);
+		weightGuideRepository.save(저장된_체중_가이드);
+
+	}
+
+	@Test
+	void 날짜별_채중_가이드를_조회한다() {
+		// given
+		WeightGuideResponse 저장된_체중_가이드_응답 = weightMapper.toResponse(저장된_체중_가이드);
+		// when
+		WeightGuideResponse weightGuideResponse = weightGuideSearchService.findGuide(테오_아이디, LocalDate.parse(생성일자));
+
+		// then
+		assertAll(
+			() -> assertThat(weightGuideResponse.bmi()).isEqualTo(저장된_체중_가이드_응답.bmi()),
+			() -> assertThat(weightGuideResponse.weightDiff()).isEqualTo(저장된_체중_가이드_응답.weightDiff()),
+			() -> assertThat(weightGuideResponse.type()).isEqualTo(저장된_체중_가이드_응답.type()),
+			() -> assertThat(weightGuideResponse.unit()).isEqualTo(저장된_체중_가이드_응답.unit()),
+			() -> assertThat(weightGuideResponse.title()).isEqualTo(저장된_체중_가이드_응답.title()),
+			() -> assertThat(weightGuideResponse.content()).isEqualTo(저장된_체중_가이드_응답.content()),
+			() -> assertThat(weightGuideResponse.createdAt()).isEqualTo(저장된_체중_가이드_응답.createdAt())
+		);
+	}
+
+	@Test
+	void 존재하지_않는_날짜의_가이드조회를_실패한다() {
+		// given
+
+		// when
+
+		// then
+		assertThrows(GuideNotFoundException.class, () -> {
+			weightGuideSearchService.findGuide(테오_아이디, LocalDate.parse("3000-12-30"));
+		});
+	}
+}

--- a/src/test/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideSearchServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideSearchServiceTest.java
@@ -18,7 +18,6 @@ import com.coniverse.dangjang.domain.guide.weight.document.WeightGuide;
 import com.coniverse.dangjang.domain.guide.weight.dto.WeightGuideResponse;
 import com.coniverse.dangjang.domain.guide.weight.mapper.WeightMapper;
 import com.coniverse.dangjang.domain.guide.weight.repository.WeightGuideRepository;
-import com.coniverse.dangjang.support.annotation.WithDangjangUser;
 
 /**
  * @author EVE
@@ -26,7 +25,6 @@ import com.coniverse.dangjang.support.annotation.WithDangjangUser;
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest
-@WithDangjangUser
 public class WeightGuideSearchServiceTest {
 	@Autowired
 	private WeightGuideRepository weightGuideRepository;
@@ -40,18 +38,18 @@ public class WeightGuideSearchServiceTest {
 
 	@BeforeAll
 	void setUp() {
+		weightGuideRepository.deleteAll();
 		저장된_체중_가이드 = 체중_가이드(테오_아이디, 생성일자);
 		weightGuideRepository.save(저장된_체중_가이드);
 
 	}
 
 	@Test
-	void 날짜별_채중_가이드를_조회한다() {
+	void 체중_가이드를_조회하여_Response를_반환한다() {
 		// given
 		WeightGuideResponse 저장된_체중_가이드_응답 = weightMapper.toResponse(저장된_체중_가이드);
 		// when
 		WeightGuideResponse weightGuideResponse = weightGuideSearchService.findGuide(테오_아이디, LocalDate.parse(생성일자));
-
 		// then
 		assertAll(
 			() -> assertThat(weightGuideResponse.bmi()).isEqualTo(저장된_체중_가이드_응답.bmi()),
@@ -73,6 +71,36 @@ public class WeightGuideSearchServiceTest {
 		// then
 		assertThrows(GuideNotFoundException.class, () -> {
 			weightGuideSearchService.findGuide(테오_아이디, LocalDate.parse("3000-12-30"));
+		});
+	}
+
+	@Test
+	void 체중_가이드를_조회히여_Document를_반환한다() {
+		// given
+
+		// when
+		WeightGuide weightGuideResponse = weightGuideSearchService.findByUserIdAndCreatedAt(테오_아이디, LocalDate.parse(생성일자));
+
+		// then
+		assertAll(
+			() -> assertThat(weightGuideResponse.getBmi()).isEqualTo(저장된_체중_가이드.getBmi()),
+			() -> assertThat(weightGuideResponse.getWeightDiff()).isEqualTo(저장된_체중_가이드.getWeightDiff()),
+			() -> assertThat(weightGuideResponse.getType()).isEqualTo(저장된_체중_가이드.getType()),
+			() -> assertThat(weightGuideResponse.getUnit()).isEqualTo(저장된_체중_가이드.getUnit()),
+			() -> assertThat(weightGuideResponse.getContent()).isEqualTo(저장된_체중_가이드.getContent()),
+			() -> assertThat(weightGuideResponse.getCreatedAt()).isEqualTo(저장된_체중_가이드.getCreatedAt())
+		);
+	}
+
+	@Test
+	void 존재하지_않는_가이드조회를_실패한다() {
+		// given
+
+		// when
+
+		// then
+		assertThrows(GuideNotFoundException.class, () -> {
+			weightGuideSearchService.findByUserIdAndCreatedAt(테오_아이디, LocalDate.parse("3000-12-30"));
 		});
 	}
 }

--- a/src/test/java/com/coniverse/dangjang/fixture/AnalysisDataFixture.java
+++ b/src/test/java/com/coniverse/dangjang/fixture/AnalysisDataFixture.java
@@ -14,6 +14,7 @@ import com.coniverse.dangjang.domain.analysis.dto.healthMetric.BloodSugarAnalysi
 import com.coniverse.dangjang.domain.analysis.dto.healthMetric.ExerciseAnalysisData;
 import com.coniverse.dangjang.domain.analysis.dto.healthMetric.WeightAnalysisData;
 import com.coniverse.dangjang.domain.analysis.enums.Alert;
+import com.coniverse.dangjang.domain.analysis.enums.ExercisePercent;
 import com.coniverse.dangjang.domain.code.enums.CommonCode;
 import com.coniverse.dangjang.domain.guide.exercise.dto.ExerciseCalorie;
 import com.coniverse.dangjang.domain.healthmetric.dto.request.HealthMetricPostRequest;
@@ -110,6 +111,10 @@ public class AnalysisDataFixture {
 		return new HealthMetricPostRequest("체중", "2023-05-06", unit);
 	}
 
+	public static HealthMetricPostRequest 운동_요청(CommonCode type, String unit) {
+		return new HealthMetricPostRequest(type.getTitle(), "2023-05-06", unit);
+	}
+
 	private static Stream<Arguments> 체중분석_입력_파라미터() {
 		UserFixture userFixture = new UserFixture();
 
@@ -122,6 +127,25 @@ public class AnalysisDataFixture {
 			Arguments.of(체중_요청("100"), userFixture.유저_테오()),
 			Arguments.of(체중_요청("120"), userFixture.유저_테오()),
 			Arguments.of(체중_요청("180"), userFixture.유저_테오())
+		);
+	}
+
+	private static int calculateCalorie(CommonCode type, int unit, int weight) {
+		double percent = ExercisePercent.findPercentByExercise(type);
+		return (int)(percent * weight / 15 * unit);
+	}
+
+	private static Stream<Arguments> 운동분석_입력_파라미터() {
+		UserFixture userFixture = new UserFixture();
+
+		return Stream.of(
+			Arguments.of(운동_요청(CommonCode.STEP_COUNT, "10000"), userFixture.유저_테오(), 0, 10000, 0),
+			Arguments.of(운동_요청(CommonCode.RUN, "100"), userFixture.유저_테오(), 0, 0, calculateCalorie(CommonCode.RUN, 100, 70)),
+			Arguments.of(운동_요청(CommonCode.HEALTH, "80"), userFixture.유저_테오(), 0, 0, calculateCalorie(CommonCode.HEALTH, 80, 70)),
+			Arguments.of(운동_요청(CommonCode.BIKE, "10"), userFixture.유저_테오(), 0, 0, calculateCalorie(CommonCode.BIKE, 10, 70)),
+			Arguments.of(운동_요청(CommonCode.HIKING, "60"), userFixture.유저_테오(), 0, 0, calculateCalorie(CommonCode.HIKING, 60, 70)),
+			Arguments.of(운동_요청(CommonCode.WALK, "120"), userFixture.유저_테오(), 0, 0, calculateCalorie(CommonCode.WALK, 120, 70)),
+			Arguments.of(운동_요청(CommonCode.SWIM, "120"), userFixture.유저_테오(), 0, 0, calculateCalorie(CommonCode.SWIM, 120, 70))
 		);
 	}
 

--- a/src/test/java/com/coniverse/dangjang/fixture/AnalysisDataFixture.java
+++ b/src/test/java/com/coniverse/dangjang/fixture/AnalysisDataFixture.java
@@ -78,7 +78,7 @@ public class AnalysisDataFixture {
 				throw new EnumNonExistentException();
 		}
 		int calorie = (int)(percent * weight / 15 * unit);
-		return new ExerciseCalorie(type, calorie);
+		return new ExerciseCalorie(type, calorie, unit);
 	}
 
 	public static WeightAnalysisData 체중_분석_데이터() {

--- a/src/test/java/com/coniverse/dangjang/fixture/AnalysisDataFixture.java
+++ b/src/test/java/com/coniverse/dangjang/fixture/AnalysisDataFixture.java
@@ -128,6 +128,18 @@ public class AnalysisDataFixture {
 		);
 	}
 
+	public static Stream<Arguments> bmi_입력_파라미터() {
+
+		return Stream.of(
+			Arguments.of(14.5, Alert.LOW_WEIGHT),
+			Arguments.of(20.9, Alert.NORMAL_WEIGHT),
+			Arguments.of(23.7, Alert.OVERWEIGHT),
+			Arguments.of(28.6, Alert.LEVEL_1_OBESITY),
+			Arguments.of(32.6, Alert.LEVEL_2_OBESITY),
+			Arguments.of(35.3, Alert.LEVEL_3_OBESITY)
+		);
+	}
+
 	private static int calculateCalorie(CommonCode type, int unit, int weight) {
 		double percent = ExercisePercent.findPercentByExercise(type);
 		return (int)(percent * weight / 15 * unit);

--- a/src/test/java/com/coniverse/dangjang/fixture/AnalysisDataFixture.java
+++ b/src/test/java/com/coniverse/dangjang/fixture/AnalysisDataFixture.java
@@ -4,6 +4,7 @@ import static com.coniverse.dangjang.fixture.HealthMetricFixture.*;
 import static com.coniverse.dangjang.fixture.UserFixture.*;
 import static org.junit.jupiter.params.provider.Arguments.*;
 
+import java.time.LocalDate;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.params.provider.Arguments;
@@ -37,20 +38,28 @@ public class AnalysisDataFixture {
 		return data;
 	}
 
-	public static AnalysisData 운동_분석_데이터(User user, CommonCode type, String unit) {
+	public static AnalysisData 운동_분석_데이터(User user, CommonCode type, String createdAt, String unit) {
+		return new ExerciseAnalysisData(건강지표_엔티티(user, type, LocalDate.parse(createdAt), unit));
+	}
+
+	public static AnalysisData 걸음수_분석_데이터(User user, CommonCode type, String unit) {
 		return new ExerciseAnalysisData(건강지표_엔티티(user, type, unit));
 	}
 
 	public static Stream<Arguments> 운동_시간_목록() {
-		return Stream.of(arguments(CommonCode.BIKE, "60"), arguments(CommonCode.HIKING, "120"), arguments(CommonCode.HEALTH, "50"),
-			arguments(CommonCode.RUN, "60"),
-			arguments(CommonCode.SWIM, "60"), arguments(CommonCode.WALK, "60"));
+		return Stream.of(arguments(CommonCode.BIKE, "2023-12-01", "60"), arguments(CommonCode.HIKING, "2023-12-01", "60"),
+			arguments(CommonCode.STEP_COUNT, "2023-12-01", "6000"),
+			arguments(CommonCode.STEP_COUNT, "2023-12-02", "6000"), arguments(CommonCode.HEALTH, "2023-12-02", "60"),
+			arguments(CommonCode.RUN, "2023-12-02", "60"),
+			arguments(CommonCode.SWIM, "2023-12-02", "60"), arguments(CommonCode.WALK, "2023-12-02", "60"));
 	}
 
 	public static Stream<Arguments> 운동_시간_수정목록() {
-		return Stream.of(arguments(CommonCode.BIKE, "900"), arguments(CommonCode.HIKING, "0"), arguments(CommonCode.HEALTH, "50"),
-			arguments(CommonCode.RUN, "40"),
-			arguments(CommonCode.SWIM, "80"), arguments(CommonCode.WALK, "120"));
+		return Stream.of(arguments(CommonCode.BIKE, "2023-12-01", "80"), arguments(CommonCode.HIKING, "2023-12-01", "69"),
+			arguments(CommonCode.STEP_COUNT, "2023-12-01", "8000"),
+			arguments(CommonCode.STEP_COUNT, "2023-12-02", "10000"), arguments(CommonCode.HEALTH, "2023-12-02", "40"),
+			arguments(CommonCode.RUN, "2023-12-02", "20"),
+			arguments(CommonCode.SWIM, "2023-12-02", "10"), arguments(CommonCode.WALK, "2023-12-02", "70"));
 	}
 
 	public static ExerciseCalorie 운동_칼로리_데이터(CommonCode type, int unit, int weight) {

--- a/src/test/java/com/coniverse/dangjang/fixture/AnalysisDataFixture.java
+++ b/src/test/java/com/coniverse/dangjang/fixture/AnalysisDataFixture.java
@@ -116,15 +116,14 @@ public class AnalysisDataFixture {
 	}
 
 	public static Stream<Arguments> 체중분석_입력_파라미터() {
-		UserFixture userFixture = new UserFixture();
-		User user = userFixture.유저_테오();
 
 		return Stream.of(
-			Arguments.of(체중_요청("40"), user, Alert.LOW_WEIGHT),
-			Arguments.of(체중_요청("90"), user, Alert.NORMAL_WEIGHT),
-			Arguments.of(체중_요청("100"), user, Alert.LEVEL_1_OBESITY),
-			Arguments.of(체중_요청("120"), user, Alert.LEVEL_2_OBESITY),
-			Arguments.of(체중_요청("180"), user, Alert.LEVEL_3_OBESITY)
+			Arguments.of(건강지표_엔티티(CommonCode.MEASUREMENT, "40"), Alert.LOW_WEIGHT),
+			Arguments.of(건강지표_엔티티(CommonCode.MEASUREMENT, "90"), Alert.NORMAL_WEIGHT),
+			Arguments.of(건강지표_엔티티(CommonCode.MEASUREMENT, "95"), Alert.OVERWEIGHT),
+			Arguments.of(건강지표_엔티티(CommonCode.MEASUREMENT, "100"), Alert.LEVEL_1_OBESITY),
+			Arguments.of(건강지표_엔티티(CommonCode.MEASUREMENT, "120"), Alert.LEVEL_2_OBESITY),
+			Arguments.of(건강지표_엔티티(CommonCode.MEASUREMENT, "180"), Alert.LEVEL_3_OBESITY)
 		);
 	}
 
@@ -146,16 +145,14 @@ public class AnalysisDataFixture {
 	}
 
 	private static Stream<Arguments> 운동분석_입력_파라미터() {
-		UserFixture userFixture = new UserFixture();
 
 		return Stream.of(
-			Arguments.of(운동_요청(CommonCode.STEP_COUNT, "10000"), userFixture.유저_테오(), 0, 10000, 0),
-			Arguments.of(운동_요청(CommonCode.RUN, "100"), userFixture.유저_테오(), 0, 0, calculateCalorie(CommonCode.RUN, 100, 70)),
-			Arguments.of(운동_요청(CommonCode.HEALTH, "80"), userFixture.유저_테오(), 0, 0, calculateCalorie(CommonCode.HEALTH, 80, 70)),
-			Arguments.of(운동_요청(CommonCode.BIKE, "10"), userFixture.유저_테오(), 0, 0, calculateCalorie(CommonCode.BIKE, 10, 70)),
-			Arguments.of(운동_요청(CommonCode.HIKING, "60"), userFixture.유저_테오(), 0, 0, calculateCalorie(CommonCode.HIKING, 60, 70)),
-			Arguments.of(운동_요청(CommonCode.WALK, "120"), userFixture.유저_테오(), 0, 0, calculateCalorie(CommonCode.WALK, 120, 70)),
-			Arguments.of(운동_요청(CommonCode.SWIM, "120"), userFixture.유저_테오(), 0, 0, calculateCalorie(CommonCode.SWIM, 120, 70))
+			Arguments.of(건강지표_엔티티(CommonCode.STEP_COUNT, "10000"), 0, 10000, 0),
+			Arguments.of(건강지표_엔티티(CommonCode.RUN, "100"), 0, 0, calculateCalorie(CommonCode.RUN, 100, 70)),
+			Arguments.of(건강지표_엔티티(CommonCode.BIKE, "10"), 0, 0, calculateCalorie(CommonCode.BIKE, 10, 70)),
+			Arguments.of(건강지표_엔티티(CommonCode.HIKING, "60"), 0, 0, calculateCalorie(CommonCode.HIKING, 60, 70)),
+			Arguments.of(건강지표_엔티티(CommonCode.WALK, "120"), 0, 0, calculateCalorie(CommonCode.WALK, 120, 70)),
+			Arguments.of(건강지표_엔티티(CommonCode.SWIM, "120"), 0, 0, calculateCalorie(CommonCode.SWIM, 120, 70))
 		);
 	}
 

--- a/src/test/java/com/coniverse/dangjang/fixture/AnalysisDataFixture.java
+++ b/src/test/java/com/coniverse/dangjang/fixture/AnalysisDataFixture.java
@@ -19,7 +19,6 @@ import com.coniverse.dangjang.domain.code.enums.CommonCode;
 import com.coniverse.dangjang.domain.guide.exercise.dto.ExerciseCalorie;
 import com.coniverse.dangjang.domain.healthmetric.dto.request.HealthMetricPostRequest;
 import com.coniverse.dangjang.domain.user.entity.User;
-import com.coniverse.dangjang.domain.user.entity.enums.Gender;
 import com.coniverse.dangjang.global.exception.EnumNonExistentException;
 
 /**
@@ -119,51 +118,14 @@ public class AnalysisDataFixture {
 	public static Stream<Arguments> 체중분석_입력_파라미터() {
 		UserFixture userFixture = new UserFixture();
 		User user = userFixture.유저_테오();
-		int 테오_키 = user.getHeight();
 
 		return Stream.of(
-			Arguments.of(체중_요청("40"), user, 표준체중과의_차이(테오_키, 40, user.getGender()), 체질량지수(테오_키, 40), 체중_비만도(테오_키, 40)),
-			Arguments.of(체중_요청("50"), user, 표준체중과의_차이(테오_키, 50, user.getGender()), 체질량지수(테오_키, 50), 체중_비만도(테오_키, 50)),
-			Arguments.of(체중_요청("60"), user, 표준체중과의_차이(테오_키, 60, user.getGender()), 체질량지수(테오_키, 60), 체중_비만도(테오_키, 60)),
-			Arguments.of(체중_요청("70"), user, 표준체중과의_차이(테오_키, 70, user.getGender()), 체질량지수(테오_키, 70), 체중_비만도(테오_키, 70)),
-			Arguments.of(체중_요청("90"), user, 표준체중과의_차이(테오_키, 90, user.getGender()), 체질량지수(테오_키, 90), 체중_비만도(테오_키, 90)),
-			Arguments.of(체중_요청("100"), user, 표준체중과의_차이(테오_키, 100, user.getGender()), 체질량지수(테오_키, 100), 체중_비만도(테오_키, 100)),
-			Arguments.of(체중_요청("120"), user, 표준체중과의_차이(테오_키, 120, user.getGender()), 체질량지수(테오_키, 120), 체중_비만도(테오_키, 120)),
-			Arguments.of(체중_요청("180"), user, 표준체중과의_차이(테오_키, 180, user.getGender()), 체질량지수(테오_키, 180), 체중_비만도(테오_키, 180))
+			Arguments.of(체중_요청("40"), user, Alert.LOW_WEIGHT),
+			Arguments.of(체중_요청("90"), user, Alert.NORMAL_WEIGHT),
+			Arguments.of(체중_요청("100"), user, Alert.LEVEL_1_OBESITY),
+			Arguments.of(체중_요청("120"), user, Alert.LEVEL_2_OBESITY),
+			Arguments.of(체중_요청("180"), user, Alert.LEVEL_3_OBESITY)
 		);
-	}
-
-	/**
-	 * 체중 분석에 필요한 메서드
-	 */
-	public static int 표준체중과의_차이(int height, int weight, Gender gender) {
-		int standardWeight;
-		if (gender.equals(Gender.M)) {
-			standardWeight = (int)(Math.pow(height / 100.0, 2.0) * 22);
-		} else {
-			standardWeight = (int)(Math.pow(height / 100.0, 2.0) * 21);
-		}
-		return weight - standardWeight;
-	}
-
-	public static double 체질량지수(int height, int weight) {
-		return weight / Math.pow(height / 100.0, 2.0);
-	}
-
-	public static Alert 체중_비만도(int height, int weight) {
-		double bmi = weight / Math.pow(height / 100.0, 2.0);
-		if (bmi < 18.5) {
-			return Alert.LOW_WEIGHT;
-		} else if (bmi < 22.9) {
-			return Alert.NORMAL_WEIGHT;
-		} else if (bmi < 24.9) {
-			return Alert.OVERWEIGHT;
-		} else if (bmi < 29.9) {
-			return Alert.LEVEL_1_OBESITY;
-		} else if (bmi < 34.9) {
-			return Alert.LEVEL_2_OBESITY;
-		}
-		return Alert.LEVEL_3_OBESITY;
 	}
 
 	private static int calculateCalorie(CommonCode type, int unit, int weight) {

--- a/src/test/java/com/coniverse/dangjang/fixture/AnalysisDataFixture.java
+++ b/src/test/java/com/coniverse/dangjang/fixture/AnalysisDataFixture.java
@@ -15,6 +15,7 @@ import com.coniverse.dangjang.domain.analysis.dto.healthMetric.WeightAnalysisDat
 import com.coniverse.dangjang.domain.analysis.enums.Alert;
 import com.coniverse.dangjang.domain.code.enums.CommonCode;
 import com.coniverse.dangjang.domain.guide.exercise.dto.ExerciseCalorie;
+import com.coniverse.dangjang.domain.healthmetric.dto.request.HealthMetricPostRequest;
 import com.coniverse.dangjang.domain.user.entity.User;
 import com.coniverse.dangjang.global.exception.EnumNonExistentException;
 
@@ -25,6 +26,7 @@ import com.coniverse.dangjang.global.exception.EnumNonExistentException;
  * @since 1.0.0
  */
 public class AnalysisDataFixture {
+
 	public static BloodSugarAnalysisData 혈당_분석_데이터(User user, CommonCode type, String unit) {
 		return new BloodSugarAnalysisData(건강지표_엔티티(user, type, unit));
 	}
@@ -94,4 +96,24 @@ public class AnalysisDataFixture {
 	public static AnalysisData 분석_데이터(CommonCode type) {
 		return new BloodSugarAnalysisData(건강지표_엔티티(type));
 	}
+
+	public static HealthMetricPostRequest 체중_요청(String unit) {
+		return new HealthMetricPostRequest("체중", "2023-05-06", unit);
+	}
+
+	private static Stream<Arguments> 체중분석_입력_파라미터() {
+		UserFixture userFixture = new UserFixture();
+
+		return Stream.of(
+			Arguments.of(체중_요청("40"), userFixture.유저_테오()),
+			Arguments.of(체중_요청("50"), userFixture.유저_테오()),
+			Arguments.of(체중_요청("60"), userFixture.유저_테오()),
+			Arguments.of(체중_요청("70"), userFixture.유저_테오()),
+			Arguments.of(체중_요청("90"), userFixture.유저_테오()),
+			Arguments.of(체중_요청("100"), userFixture.유저_테오()),
+			Arguments.of(체중_요청("120"), userFixture.유저_테오()),
+			Arguments.of(체중_요청("180"), userFixture.유저_테오())
+		);
+	}
+
 }

--- a/src/test/java/com/coniverse/dangjang/fixture/GuideFixture.java
+++ b/src/test/java/com/coniverse/dangjang/fixture/GuideFixture.java
@@ -14,11 +14,13 @@ import com.coniverse.dangjang.domain.guide.bloodsugar.document.TodayGuide;
 import com.coniverse.dangjang.domain.guide.bloodsugar.dto.BloodSugarGuideResponse;
 import com.coniverse.dangjang.domain.guide.bloodsugar.dto.SubGuideResponse;
 import com.coniverse.dangjang.domain.guide.common.dto.GuideResponse;
+import com.coniverse.dangjang.domain.guide.weight.document.WeightGuide;
+import com.coniverse.dangjang.domain.guide.weight.dto.WeightGuideResponse;
 
 /**
  * 가이드 fixture
  *
- * @author TEO
+ * @author TEO, EVE
  * @since 1.0.0
  */
 public class GuideFixture {
@@ -48,6 +50,18 @@ public class GuideFixture {
 		return 혈당_가이드_도큐먼트("11111111", createdAt).getTodayGuides();
 	}
 
+	public static WeightGuide 체중_가이드(String oauthId, String createdAt) {
+		return WeightGuide.builder()
+			.oauthId(oauthId)
+			.createdAt(LocalDate.parse(createdAt))
+			.bmi(18.5)
+			.unit("80")
+			.weightDiff(10)
+			.alert(Alert.LEVEL_1_OBESITY)
+			.content("가이드 내용입니다.")
+			.build();
+	}
+
 	public static BloodSugarGuideResponse 혈당_가이드_응답(String createdAt) {
 		List<TodayGuide> 오늘의_가이드 = 혈당_오늘의_가이드(createdAt);
 		List<SubGuideResponse> 서브_가이드 = new ArrayList<>();
@@ -68,8 +82,9 @@ public class GuideFixture {
 		return null;
 	}
 
-	public static GuideResponse 체중_가이드_응답() { // TODO return 수정
-		return null;
+	public static WeightGuideResponse 체중_가이드_응답(String createdAt) {
+		return new WeightGuideResponse(CommonCode.MEASUREMENT.getTitle(), LocalDate.parse(createdAt), 20, Alert.LEVEL_1_OBESITY.getTitle(), "가이드입니다", 18.0,
+			"50");
 	}
 
 	public static GuideResponse 당화혈색소_가이드_응답() { // TODO return 수정

--- a/src/test/java/com/coniverse/dangjang/fixture/GuideFixture.java
+++ b/src/test/java/com/coniverse/dangjang/fixture/GuideFixture.java
@@ -53,7 +53,7 @@ public class GuideFixture {
 	public static WeightGuide 체중_가이드(String oauthId, String createdAt) {
 		return WeightGuide.builder()
 			.oauthId(oauthId)
-			.createdAt(LocalDate.parse(createdAt))
+			.createdAt(createdAt)
 			.bmi(18.5)
 			.unit("80")
 			.weightDiff(10)
@@ -83,7 +83,7 @@ public class GuideFixture {
 	}
 
 	public static WeightGuideResponse 체중_가이드_응답(String createdAt) {
-		return new WeightGuideResponse(CommonCode.MEASUREMENT.getTitle(), LocalDate.parse(createdAt), 20, Alert.LEVEL_1_OBESITY.getTitle(), "가이드입니다", 18.0,
+		return new WeightGuideResponse(CommonCode.MEASUREMENT.getTitle(), createdAt, 20, Alert.LEVEL_1_OBESITY.getTitle(), "가이드입니다", 18.0,
 			"50");
 	}
 

--- a/src/test/java/com/coniverse/dangjang/fixture/GuideFixture.java
+++ b/src/test/java/com/coniverse/dangjang/fixture/GuideFixture.java
@@ -100,9 +100,9 @@ public class GuideFixture {
 			"50");
 	}
 
-	public static ExerciseGuideResponse 운동_가이드_응답(String oauthId, String 조회_날짜) {
+	public static ExerciseGuideResponse 운동_가이드_응답(String 조회_날짜) {
 		List<ExerciseCalorie> exerciseCalories = List.of(new ExerciseCalorie(CommonCode.HEALTH, 100, 60), new ExerciseCalorie(CommonCode.RUN, 200, 120));
-		return new ExerciseGuideResponse(조회_날짜, 0, 0, "저번주 대비 가이드입니다.", "가이드 내용입니다.", 0, exerciseCalories);
+		return new ExerciseGuideResponse(조회_날짜, 5, 55, "저번주 대비 가이드입니다.", "가이드 내용입니다.", 0, exerciseCalories);
 	}
 
 	public static GuideResponse 당화혈색소_가이드_응답() { // TODO return 수정

--- a/src/test/java/com/coniverse/dangjang/fixture/GuideFixture.java
+++ b/src/test/java/com/coniverse/dangjang/fixture/GuideFixture.java
@@ -14,6 +14,9 @@ import com.coniverse.dangjang.domain.guide.bloodsugar.document.TodayGuide;
 import com.coniverse.dangjang.domain.guide.bloodsugar.dto.BloodSugarGuideResponse;
 import com.coniverse.dangjang.domain.guide.bloodsugar.dto.SubGuideResponse;
 import com.coniverse.dangjang.domain.guide.common.dto.GuideResponse;
+import com.coniverse.dangjang.domain.guide.exercise.document.ExerciseGuide;
+import com.coniverse.dangjang.domain.guide.exercise.dto.ExerciseCalorie;
+import com.coniverse.dangjang.domain.guide.exercise.dto.ExerciseGuideResponse;
 import com.coniverse.dangjang.domain.guide.weight.document.WeightGuide;
 import com.coniverse.dangjang.domain.guide.weight.dto.WeightGuideResponse;
 
@@ -62,6 +65,20 @@ public class GuideFixture {
 			.build();
 	}
 
+	public static ExerciseGuide 운동_가이드(String oauthId, String 조회_날짜) {
+		List<ExerciseCalorie> exerciseCalories = List.of(new ExerciseCalorie(CommonCode.HEALTH, 100, 60), new ExerciseCalorie(CommonCode.RUN, 200, 120));
+
+		return ExerciseGuide.builder()
+			.oauthId(oauthId)
+			.needStepByLastWeek(0)
+			.comparedToLastWeek("저번주 대비 가이드입니다.")
+			.content("가이드 내용입니다.")
+			.createdAt(조회_날짜)
+			.stepsCount(0)
+			.exerciseCalories(exerciseCalories)
+			.build();
+	}
+
 	public static BloodSugarGuideResponse 혈당_가이드_응답(String createdAt) {
 		List<TodayGuide> 오늘의_가이드 = 혈당_오늘의_가이드(createdAt);
 		List<SubGuideResponse> 서브_가이드 = new ArrayList<>();
@@ -78,13 +95,14 @@ public class GuideFixture {
 			혈당_오늘의_가이드(LocalDate.now().toString()));
 	}
 
-	public static GuideResponse 운동_가이드_응답() { // TODO return 수정
-		return null;
-	}
-
 	public static WeightGuideResponse 체중_가이드_응답(String createdAt) {
 		return new WeightGuideResponse(CommonCode.MEASUREMENT.getTitle(), createdAt, 20, Alert.LEVEL_1_OBESITY.getTitle(), "가이드입니다", 18.0,
 			"50");
+	}
+
+	public static ExerciseGuideResponse 운동_가이드_응답(String oauthId, String 조회_날짜) {
+		List<ExerciseCalorie> exerciseCalories = List.of(new ExerciseCalorie(CommonCode.HEALTH, 100, 60), new ExerciseCalorie(CommonCode.RUN, 200, 120));
+		return new ExerciseGuideResponse(조회_날짜, 0, 0, "저번주 대비 가이드입니다.", "가이드 내용입니다.", 0, exerciseCalories);
 	}
 
 	public static GuideResponse 당화혈색소_가이드_응답() { // TODO return 수정

--- a/src/test/java/com/coniverse/dangjang/fixture/HealthMetricFixture.java
+++ b/src/test/java/com/coniverse/dangjang/fixture/HealthMetricFixture.java
@@ -100,6 +100,15 @@ public class HealthMetricFixture {
 			.build();
 	}
 
+	public static HealthMetric 건강지표_엔티티(User user, CommonCode type, LocalDate createdAt, String unit) {
+		return HealthMetric.builder()
+			.createdAt(createdAt)
+			.type(type)
+			.user(user)
+			.unit(unit)
+			.build();
+	}
+
 	/**
 	 * 가이드 데이터 fixture에서 사용
 	 */

--- a/src/test/java/com/coniverse/dangjang/support/ControllerTest.java
+++ b/src/test/java/com/coniverse/dangjang/support/ControllerTest.java
@@ -13,6 +13,8 @@ import com.coniverse.dangjang.domain.auth.service.JwtTokenProvider;
 import com.coniverse.dangjang.domain.auth.service.OauthLoginService;
 import com.coniverse.dangjang.domain.guide.bloodsugar.controller.BloodSugarGuideController;
 import com.coniverse.dangjang.domain.guide.bloodsugar.service.BloodSugarGuideSearchService;
+import com.coniverse.dangjang.domain.guide.weight.controller.WeightGuideController;
+import com.coniverse.dangjang.domain.guide.weight.service.WeightGuideSearchService;
 import com.coniverse.dangjang.domain.healthmetric.controller.HealthMetricRegisterController;
 import com.coniverse.dangjang.domain.healthmetric.service.HealthMetricRegisterService;
 import com.coniverse.dangjang.domain.intro.controller.IntroController;
@@ -37,7 +39,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 		LoginController.class,
 		SignupController.class,
 		UserController.class,
-		BloodSugarGuideController.class
+		BloodSugarGuideController.class,
+		WeightGuideController.class
 	},
 	includeFilters = @ComponentScan.Filter(classes = {EnableWebSecurity.class}))
 @ComponentScan(basePackages = "com.coniverse.dangjang.domain.auth.handler")
@@ -59,4 +62,6 @@ public class ControllerTest {
 	private JwtTokenProvider jwtTokenProvider;
 	@MockBean
 	private BloodSugarGuideSearchService bloodSugarGuideSearchService;
+	@MockBean
+	private WeightGuideSearchService weightGuideSearchService;
 }

--- a/src/test/java/com/coniverse/dangjang/support/ControllerTest.java
+++ b/src/test/java/com/coniverse/dangjang/support/ControllerTest.java
@@ -13,6 +13,8 @@ import com.coniverse.dangjang.domain.auth.service.JwtTokenProvider;
 import com.coniverse.dangjang.domain.auth.service.OauthLoginService;
 import com.coniverse.dangjang.domain.guide.bloodsugar.controller.BloodSugarGuideController;
 import com.coniverse.dangjang.domain.guide.bloodsugar.service.BloodSugarGuideSearchService;
+import com.coniverse.dangjang.domain.guide.exercise.controller.ExerciseGuideController;
+import com.coniverse.dangjang.domain.guide.exercise.service.ExerciseGuideSearchService;
 import com.coniverse.dangjang.domain.guide.weight.controller.WeightGuideController;
 import com.coniverse.dangjang.domain.guide.weight.service.WeightGuideSearchService;
 import com.coniverse.dangjang.domain.healthmetric.controller.HealthMetricRegisterController;
@@ -40,7 +42,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 		SignupController.class,
 		UserController.class,
 		BloodSugarGuideController.class,
-		WeightGuideController.class
+		WeightGuideController.class,
+		ExerciseGuideController.class
 	},
 	includeFilters = @ComponentScan.Filter(classes = {EnableWebSecurity.class}))
 @ComponentScan(basePackages = "com.coniverse.dangjang.domain.auth.handler")
@@ -64,4 +67,6 @@ public class ControllerTest {
 	private BloodSugarGuideSearchService bloodSugarGuideSearchService;
 	@MockBean
 	private WeightGuideSearchService weightGuideSearchService;
+	@MockBean
+	private ExerciseGuideSearchService exerciseGuideSearchService;
 }


### PR DESCRIPTION
# Changes 📝
- 운동  createdAt 타입 String으로 변경
- 운동 가이드에 운동 시간 추가
- 운동 가이드 조회 api 구현
- feat/Weight 브랜치에서 파생된 브랜치입니다. (merge 완료)
## Details 🌼
`/api/guide/exercise?date={날짜}` 엔드포인트로 요청을 받으면 아래와 같은 reposon을 전달합니다.

```
{
    "success": true,
    "errorCode": 0,
    "message": "OK",
    "data": {
        "createdAt": "2023-12-24",
        "needStepByTTS": -5000,
        "needStepByLastWeek": 5000,
        "comparedToLastWeek": "지난주 평균 걸음 수보다 5000 걸음 더 걸었어요. 좋아요~",
        "content": "만보를 걷기 위해 -5000 걸음 부족해요! 조금만 더 걸어볼까요?",
        "stepsCount": 8000,
        "exerciseCalories": [
            {
                "type": "HEALTH",
                "calorie": 800,
                "exerciseTime": 100
            },
            {
                "type": "WALK",
                "calorie": 576,
                "exerciseTime": 120
            },
            {
                "type": "SWIM",
                "calorie": 1280,
                "exerciseTime": 120
            },
            {
                "type": "BIKE",
                "calorie": 1472,
                "exerciseTime": 120
            },
            {
                "type": "RUN",
                "calorie": 853,
                "exerciseTime": 80
            },
            {
                "type": "HIKING",
                "calorie": 640,
                "exerciseTime": 80
            }
        ]
    }
}
```


만약 희망 날짜에 가이드가 없다면 에러를 전달합니다.

```
{
    "success": false,
    "errorCode": 404,
    "message": "가이드를 찾을 수 없습니다."
}
```



## Check List ☑️
- [x] 테스트 코드를 통과했다.
- [x] merge할 브랜치의 위치를 확인했다. (main ❌)
- [x] Assignee를 지정했다.
- [x] Label을 지정했다.

