### PR TITLE
체중 업데이트 안됨 버그 수정 및 가이드 메세지 줄바꿈

### DIFF
--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/document/ExerciseGuide.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/document/ExerciseGuide.java
@@ -57,11 +57,12 @@ public class ExerciseGuide {
 	 * @param content            만보 대비 걸음수에 대한 가이드
 	 * @since 1.0.0
 	 */
-	public void changeAboutWalk(int needStepByTTS, int needStepByLastWeek, String comparedToLastWeek, String content) {
+	public void changeAboutWalk(int needStepByTTS, int needStepByLastWeek, String comparedToLastWeek, String content, int stepsCount) {
 		this.needStepByTTS = needStepByTTS;
 		this.needStepByLastWeek = needStepByLastWeek;
 		this.comparedToLastWeek = comparedToLastWeek;
 		this.content = content;
+		this.stepsCount = stepsCount;
 	}
 
 	/**

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/enums/GuideString.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/enums/GuideString.java
@@ -13,8 +13,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum GuideString {
 
-	NEED_MORE("부족해요! 조금만 더 걸어볼까요?", "덜 걸었어요~ "),
-	ENOUGH("더 걸었군요! 멋져요~", "더 걸었어요. 좋아요~");
+	NEED_MORE("부족해요! \n조금만 더 걸어볼까요?", "덜 걸었어요~ "),
+	ENOUGH("더 걸었군요! \n멋져요~", "더 걸었어요. \n좋아요~");
 
 	private final String tenThousandStepMode;
 	private final String lastWeekMode;

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateService.java
@@ -65,7 +65,7 @@ public class ExerciseGuideGenerateService implements GuideGenerateService {
 		// 걸음 수 추가
 		if (exerciseAnalysisData.getType().equals(CommonCode.STEP_COUNT)) {
 			existExerciseGuide.changeAboutWalk(exerciseAnalysisData.needStepByTTS, exerciseAnalysisData.needStepByLastWeek,
-				walkGuideContent.getGuideLastWeek(), walkGuideContent.getGuideTTS());
+				walkGuideContent.getGuideLastWeek(), walkGuideContent.getGuideTTS(), exerciseAnalysisData.getUnit());
 			return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(existExerciseGuide));
 		}
 		//운동 추가
@@ -96,7 +96,7 @@ public class ExerciseGuideGenerateService implements GuideGenerateService {
 		if (analysisData.getType().equals(CommonCode.STEP_COUNT)) {
 			WalkGuideContent walkGuideContent = new WalkGuideContent(exerciseAnalysisData.getNeedStepByTTS(), exerciseAnalysisData.getNeedStepByLastWeek());
 			updateExerciseGuide.changeAboutWalk(exerciseAnalysisData.needStepByTTS, exerciseAnalysisData.needStepByLastWeek,
-				walkGuideContent.getGuideLastWeek(), walkGuideContent.getGuideTTS());
+				walkGuideContent.getGuideLastWeek(), walkGuideContent.getGuideTTS(), exerciseAnalysisData.getUnit());
 			return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(updateExerciseGuide));
 		}
 		//운동 수정

--- a/src/main/java/com/coniverse/dangjang/domain/guide/weight/document/WeightGuide.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/weight/document/WeightGuide.java
@@ -52,10 +52,11 @@ public class WeightGuide {
 	 * @param content    가이드 내용
 	 * @since 1.0.0
 	 */
-	public void changeAboutWeight(int weightDiff, Alert alert, String content, double bmi) {
+	public void changeAboutWeight(int weightDiff, Alert alert, String content, double bmi, String unit) {
 		this.weightDiff = weightDiff;
 		this.alert = alert;
 		this.content = content;
 		this.bmi = bmi;
+		this.unit = unit;
 	}
 }

--- a/src/main/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideGenerateService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideGenerateService.java
@@ -53,7 +53,7 @@ public class WeightGuideGenerateService implements GuideGenerateService {
 		WeightAnalysisData data = (WeightAnalysisData)analysisData;
 		WeightGuide weightGuide = weightGuideSearchService.findByUserIdAndCreatedAt(data.getOauthId(), data.getCreatedAt().toString());
 		String content = createContent(data);
-		weightGuide.changeAboutWeight(data.getWeightDiff(), data.getAlert(), content, data.getBmi());
+		weightGuide.changeAboutWeight(data.getWeightDiff(), data.getAlert(), content, data.getBmi(), String.valueOf(data.getUnit()));
 		return weightMapper.toResponse(weightGuideRepository.save(weightGuide));
 	}
 


### PR DESCRIPTION
# Changes 📝
*작업 내용을 작성합니다.*
- 체중 unit 업데이트
- 걸음수 stepsCount 업데이트
- 가이드 메세지 줄바꿈

## Details 🌼
체중 가이드와 운동 가이드에 각각 unit과 stepsCount를 추가하게 되면서, update에 누락되었습니다.
response의 data.unit에는 수정된 값이 제대로 뜨지만, data.guide의 unit과 stepscount에는 수정된 값이 반영되지 않는 버그가 발생하여 수정하였습니다.
다음부터 더 꼼꼼히 확인하겠습니다. 😢 

또한 클라이언트의 요청에 따라 가이드 메세지를 변경하였습니다.

## Check List ☑️
- [x] 테스트 코드를 통과했다.
- [x] merge할 브랜치의 위치를 확인했다. (main ❌)
- [x] Assignee를 지정했다.
- [x] Label을 지정했다.


