### PR TITLE
홈 하루 요약 가이드 조회 

### DIFF
--- a/src/main/java/com/coniverse/dangjang/domain/guide/common/controller/GuideController.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/common/controller/GuideController.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
  * @author EVE
  * @since 1.0.0
  */
-@RequestMapping("/api/guide/day")
+@RequestMapping("/api/guide")
 @RestController
 @RequiredArgsConstructor
 @Validated

--- a/src/main/java/com/coniverse/dangjang/domain/guide/common/controller/GuideController.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/common/controller/GuideController.java
@@ -1,0 +1,46 @@
+package com.coniverse.dangjang.domain.guide.common.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.coniverse.dangjang.domain.guide.common.dto.DayGuideResponse;
+import com.coniverse.dangjang.domain.guide.common.service.DayGuideService;
+import com.coniverse.dangjang.global.dto.SuccessSingleResponse;
+import com.coniverse.dangjang.global.validator.ValidLocalDate;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 하루 가이드 조회 Controller
+ *
+ * @author EVE
+ * @since 1.0.0
+ */
+@RequestMapping("/api/guide/day")
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class GuideController {
+	private final DayGuideService dayGuideService;
+
+	/**
+	 * 하루 요약 가이드를 조회하여 전달한다
+	 *
+	 * @param date 조회날짜
+	 * @author EVE
+	 * @since 1.0.0
+	 */
+	@GetMapping
+	public ResponseEntity<SuccessSingleResponse<DayGuideResponse>> getDayGuide(@ValidLocalDate @RequestParam String date,
+		@AuthenticationPrincipal User principal) {
+		DayGuideResponse dayGuideResponse = dayGuideService.getDayGuide(principal.getUsername(), date);
+		return ResponseEntity.ok().body(new SuccessSingleResponse<>(HttpStatus.OK.getReasonPhrase(), dayGuideResponse));
+	}
+}

--- a/src/main/java/com/coniverse/dangjang/domain/guide/common/dto/DayGuideResponse.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/common/dto/DayGuideResponse.java
@@ -1,0 +1,19 @@
+package com.coniverse.dangjang.domain.guide.common.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.coniverse.dangjang.domain.guide.bloodsugar.document.TodayGuide;
+import com.coniverse.dangjang.domain.guide.exercise.dto.ExerciseDayGuide;
+import com.coniverse.dangjang.domain.guide.weight.dto.WeightDayGuide;
+
+/**
+ * 하루 가이드 조회 응답
+ *
+ * @author EVE
+ * @since 1.0.0
+ */
+public record DayGuideResponse(String nickname, LocalDate date, List<TodayGuide> bloodSugars, WeightDayGuide weight, ExerciseDayGuide exercise,
+							   boolean notification) {
+
+}

--- a/src/main/java/com/coniverse/dangjang/domain/guide/common/service/DayGuideService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/common/service/DayGuideService.java
@@ -59,9 +59,10 @@ public class DayGuideService {
 	 *
 	 * @param oauthId 유저아이디
 	 * @param date    조회 날짜
+	 * @return List<TodayGuide> 혈당 하루 가이드
 	 * @since 1.0.0
 	 */
-	public List<TodayGuide> getBloodSugarTodayGuide(String oauthId, LocalDate date) {
+	private List<TodayGuide> getBloodSugarTodayGuide(String oauthId, LocalDate date) {
 		try {
 			return bloodSugarGuideSearchService.findByUserIdAndCreatedAt(oauthId, date).getTodayGuides();
 		} catch (GuideNotFoundException e) {
@@ -69,7 +70,15 @@ public class DayGuideService {
 		}
 	}
 
-	public WeightDayGuide getWeightGuide(String oauthId, String date) {
+	/**
+	 * 체중 하루 가이드를 조회한다.
+	 *
+	 * @param oauthId 유저아이디
+	 * @param date    조회 날짜
+	 * @return WeightDayGuide 체중 하루 가이드
+	 * @since 1.0.0
+	 */
+	private WeightDayGuide getWeightGuide(String oauthId, String date) {
 		try {
 			WeightGuide weightGuide = weightGuideSearchService.findByUserIdAndCreatedAt(oauthId, date);
 			return new WeightDayGuide(weightGuide.getUnit(), weightGuide.getBmi(), weightGuide.getContent());
@@ -78,10 +87,21 @@ public class DayGuideService {
 		}
 	}
 
-	public ExerciseDayGuide getExerciseGuide(String oauthId, LocalDate date) {
+	/**
+	 * 운동 하루 가이드를 조회한다.
+	 *
+	 * @param oauthId 유저아이디
+	 * @param date    조회 날짜
+	 * @return ExerciseDayGuide 운동 하루 가이드
+	 * @since 1.0.0
+	 */
+	private ExerciseDayGuide getExerciseGuide(String oauthId, LocalDate date) {
 		try {
 			ExerciseGuide exerciseGuide = exerciseGuideSearchService.findByOauthIdAndCreatedAt(oauthId, date);
-			int sumCalorie = exerciseGuide.getExerciseCalories().stream().mapToInt(ExerciseCalorie::calorie).sum();
+			int sumCalorie = exerciseGuide.getExerciseCalories()
+				.stream()
+				.mapToInt(ExerciseCalorie::calorie)
+				.sum();
 			return new ExerciseDayGuide(sumCalorie, exerciseGuide.getStepCount());
 		} catch (GuideNotFoundException e) {
 			return new ExerciseDayGuide(0, 0);

--- a/src/main/java/com/coniverse/dangjang/domain/guide/common/service/DayGuideService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/common/service/DayGuideService.java
@@ -1,0 +1,57 @@
+package com.coniverse.dangjang.domain.guide.common.service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.coniverse.dangjang.domain.guide.bloodsugar.document.TodayGuide;
+import com.coniverse.dangjang.domain.guide.bloodsugar.service.BloodSugarGuideSearchService;
+import com.coniverse.dangjang.domain.guide.common.dto.DayGuideResponse;
+import com.coniverse.dangjang.domain.guide.exercise.document.ExerciseCalorie;
+import com.coniverse.dangjang.domain.guide.exercise.document.ExerciseGuide;
+import com.coniverse.dangjang.domain.guide.exercise.dto.ExerciseDayGuide;
+import com.coniverse.dangjang.domain.guide.exercise.service.ExerciseGuideSearchService;
+import com.coniverse.dangjang.domain.guide.weight.document.WeightGuide;
+import com.coniverse.dangjang.domain.guide.weight.dto.WeightDayGuide;
+import com.coniverse.dangjang.domain.guide.weight.service.WeightGuideSearchService;
+import com.coniverse.dangjang.domain.user.service.UserSearchService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 하루 가이드 조회 Service
+ *
+ * @author EVE
+ * @since 1.0.0
+ */
+@Service
+@RequiredArgsConstructor
+public class DayGuideService {
+	private final UserSearchService userSearchService;
+	private final BloodSugarGuideSearchService bloodSugarGuideSearchService;
+	private final WeightGuideSearchService weightGuideSearchService;
+	private final ExerciseGuideSearchService exerciseGuideSearchService;
+
+	/**
+	 * 하루 가이드를 조회한다.
+	 * <p>
+	 * 홈에 필요한 유저 닉네임,날짜,혈당 가이드,체중 가이드,운동 가이드,알림 여부를 조회해 전달한다.
+	 *
+	 * @param oauthId 유저아이디
+	 * @param date    조회 날짜
+	 * @author EVE
+	 * @since 1.0.0
+	 */
+	public DayGuideResponse getDayGuide(String oauthId, String date) {
+		LocalDate localDate = LocalDate.parse(date);
+		String userNickname = userSearchService.findUserByOauthId(oauthId).getNickname();
+		List<TodayGuide> bloodSugarTodayGuide = bloodSugarGuideSearchService.findByUserIdAndCreatedAt(oauthId, localDate).getTodayGuides();
+		WeightGuide weightGuide = weightGuideSearchService.findByUserIdAndCreatedAt(oauthId, date);
+		WeightDayGuide weightDayGuide = new WeightDayGuide(weightGuide.getUnit(), weightGuide.getBmi(), weightGuide.getWeightDiff());
+		ExerciseGuide exerciseGuide = exerciseGuideSearchService.findByOauthIdAndCreatedAt(oauthId, localDate);
+		int sumCalorie = exerciseGuide.getExerciseCalories().stream().mapToInt(ExerciseCalorie::calorie).sum();
+		ExerciseDayGuide exerciseDayGuide = new ExerciseDayGuide(sumCalorie, exerciseGuide.getStepCount());
+		return new DayGuideResponse(userNickname, localDate, bloodSugarTodayGuide, weightDayGuide, exerciseDayGuide, false);
+	}
+}

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/dto/ExerciseDayGuide.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/dto/ExerciseDayGuide.java
@@ -1,0 +1,12 @@
+package com.coniverse.dangjang.domain.guide.exercise.dto;
+
+/**
+ * 운동 하루 요약 가이드
+ * <p>
+ * 홈에 필요한 운동 가이드 정보를 가짐
+ *
+ * @author EVE
+ * @since 1.0.0
+ */
+public record ExerciseDayGuide(int calorie, int stepCount) {
+}

--- a/src/main/java/com/coniverse/dangjang/domain/guide/weight/dto/WeightDayGuide.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/weight/dto/WeightDayGuide.java
@@ -1,0 +1,12 @@
+package com.coniverse.dangjang.domain.guide.weight.dto;
+
+/**
+ * 체중 하루 요약 가이드
+ * <p>
+ * 홈에 필요한 운동 가이드 정보를 가짐
+ *
+ * @author EVE
+ * @since 1.0.0
+ */
+public record WeightDayGuide(String unit, double bmi, int weightDiff) {
+}

--- a/src/main/java/com/coniverse/dangjang/domain/guide/weight/dto/WeightDayGuide.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/weight/dto/WeightDayGuide.java
@@ -8,5 +8,5 @@ package com.coniverse.dangjang.domain.guide.weight.dto;
  * @author EVE
  * @since 1.0.0
  */
-public record WeightDayGuide(String unit, double bmi, int weightDiff) {
+public record WeightDayGuide(String unit, double bmi, String title) {
 }

--- a/src/main/java/com/coniverse/dangjang/domain/healthmetric/service/HealthMetricChartSearchService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/healthmetric/service/HealthMetricChartSearchService.java
@@ -66,7 +66,6 @@ public class HealthMetricChartSearchService {
 
 	private List<BloodSugarMinMax> findBloodSugarMinMaxes(String oauthId, LocalDate startDate, LocalDate endDate) {
 		List<BloodSugarMinMax> bloodSugarMinMaxes = new ArrayList<>();
-
 		List<HealthMetric> bloodSugarHealthMetric = healthMetricSearchService.findWeeklyHealthMetricByGroupCode(oauthId, GroupCode.BLOOD_SUGAR,
 			startDate, endDate);
 		Map<LocalDate, List<HealthMetric>> bloodSugarMapByDate = bloodSugarHealthMetric.stream().collect(Collectors.groupingBy(HealthMetric::getCreatedAt));
@@ -92,7 +91,6 @@ public class HealthMetricChartSearchService {
 	 */
 	private List<HealthMetricChartData> findWeights(String oauthId, LocalDate startDate, LocalDate endDate) {
 		List<HealthMetricChartData> weights = new ArrayList<>();
-
 		List<HealthMetric> healthMetrics = healthMetricSearchService.findWeeklyHealthMetricByGroupCode(oauthId, GroupCode.WEIGHT, startDate, endDate);
 		healthMetrics.forEach(healthMetric ->
 			weights.add(new HealthMetricChartData(healthMetric.getCreatedAt(), Integer.parseInt(healthMetric.getUnit())))
@@ -132,8 +130,13 @@ public class HealthMetricChartSearchService {
 		List<HealthMetricChartData> exerciseCalories = new ArrayList<>();
 		List<ExerciseGuide> exerciseGuides = exerciseGuideSearchService.findWeekByOauthIdAndCreatedAt(oauthId, startDate, endDate);
 		exerciseGuides.forEach(exerciseGuide -> {
-			int calorie = exerciseGuide.getExerciseCalories().stream().mapToInt(exerciseCalorie -> exerciseCalorie.calorie()).sum();
-			exerciseCalories.add(new HealthMetricChartData(localDateChangeUtil.convertDateToKST(exerciseGuide.getCreatedAt()), calorie));
+			int calorie = exerciseGuide.getExerciseCalories()
+				.stream()
+				.mapToInt(exerciseCalorie -> exerciseCalorie.calorie())
+				.sum();
+			if (calorie != 0) { //TODO 람다로 해결
+				exerciseCalories.add(new HealthMetricChartData(localDateChangeUtil.convertDateToKST(exerciseGuide.getCreatedAt()), calorie));
+			}
 		});
 		return exerciseCalories;
 	}

--- a/src/test/java/com/coniverse/dangjang/domain/guide/common/controller/DayGuideControllerTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/common/controller/DayGuideControllerTest.java
@@ -1,0 +1,73 @@
+package com.coniverse.dangjang.domain.guide.common.controller;
+
+import static com.coniverse.dangjang.fixture.GuideFixture.*;
+import static com.coniverse.dangjang.fixture.UserFixture.*;
+import static com.coniverse.dangjang.support.SimpleMockMvc.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import com.coniverse.dangjang.domain.guide.common.dto.DayGuideResponse;
+import com.coniverse.dangjang.domain.guide.common.service.DayGuideService;
+import com.coniverse.dangjang.domain.user.entity.User;
+import com.coniverse.dangjang.support.ControllerTest;
+import com.coniverse.dangjang.support.annotation.WithDangjangUser;
+
+/**
+ * @author EVE
+ * @since 1.0.0
+ */
+@WithDangjangUser
+class DayGuideControllerTest extends ControllerTest {
+	@Autowired
+	private DayGuideService dayGuideService;
+	private static final String URL = "/api/guide/day";
+	private User user = 유저_테오();
+	private String 테오_닉네임 = user.getNickname();
+	private String 조회_날짜 = "2023-12-31";
+	private LocalDate 조회_날짜_Date = LocalDate.parse(조회_날짜);
+	private String 유효하지_않은_날짜 = "2023-12-35";
+	private DayGuideResponse 조회_응답 = 하루_가이드_응답(테오_닉네임, 조회_날짜_Date, 혈당_오늘의_가이드(조회_날짜), 체중_하루_가이드(), 운동_하루_가이드());
+
+	@Test
+	void 하루_가이드를_조회하면_성공을_반환한다() throws Exception {
+		//given
+		doReturn(조회_응답).when(dayGuideService).getDayGuide(any(), any());
+
+		MultiValueMap<String, String> parms = new LinkedMultiValueMap<>();
+		parms.add("date", 조회_날짜);
+		//when
+		ResultActions resultActions = get(mockMvc, URL, parms);
+		//then
+		resultActions.andExpectAll(
+			status().isOk(),
+			jsonPath("$.data.nickname").value(테오_닉네임),
+			jsonPath("$.data.date").value(조회_날짜),
+			jsonPath("$.data.bloodSugars").isNotEmpty(),
+			jsonPath("$.data.weight").isNotEmpty(),
+			jsonPath("$.data.exercise").isNotEmpty()
+		);
+	}
+
+	@Test
+	void 유효하지_않는_날짜로_하루_가이드를_조회하면_400을_반환한다() throws Exception {
+		//given
+
+		MultiValueMap<String, String> parms = new LinkedMultiValueMap<>();
+		parms.add("date", 유효하지_않은_날짜);
+		//when
+		ResultActions resultActions = get(mockMvc, URL, parms);
+		//then
+		resultActions.andExpectAll(
+			status().isBadRequest(),
+			jsonPath("$.errorCode").value(400)
+		);
+	}
+}

--- a/src/test/java/com/coniverse/dangjang/domain/guide/common/controller/DayGuideControllerTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/common/controller/DayGuideControllerTest.java
@@ -51,8 +51,8 @@ class DayGuideControllerTest extends ControllerTest {
 			jsonPath("$.data.nickname").value(테오_닉네임),
 			jsonPath("$.data.date").value(조회_날짜),
 			jsonPath("$.data.bloodSugars").isNotEmpty(),
-			jsonPath("$.data.weight").isNotEmpty(),
-			jsonPath("$.data.exercise").isNotEmpty()
+			jsonPath("$.data.weight.unit").value(조회_응답.weight().unit()),
+			jsonPath("$.data.exercise.stepCount").value(조회_응답.exercise().stepCount())
 		);
 	}
 

--- a/src/test/java/com/coniverse/dangjang/domain/guide/common/controller/DayGuideControllerTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/common/controller/DayGuideControllerTest.java
@@ -28,7 +28,7 @@ import com.coniverse.dangjang.support.annotation.WithDangjangUser;
 class DayGuideControllerTest extends ControllerTest {
 	@Autowired
 	private DayGuideService dayGuideService;
-	private static final String URL = "/api/guide/day";
+	private static final String URL = "/api/guide";
 	private User user = 유저_테오();
 	private String 테오_닉네임 = user.getNickname();
 	private String 조회_날짜 = "2023-12-31";
@@ -41,10 +41,10 @@ class DayGuideControllerTest extends ControllerTest {
 		//given
 		doReturn(조회_응답).when(dayGuideService).getDayGuide(any(), any());
 
-		MultiValueMap<String, String> parms = new LinkedMultiValueMap<>();
-		parms.add("date", 조회_날짜);
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("date", 조회_날짜);
 		//when
-		ResultActions resultActions = get(mockMvc, URL, parms);
+		ResultActions resultActions = get(mockMvc, URL, params);
 		//then
 		resultActions.andExpectAll(
 			status().isOk(),
@@ -60,10 +60,10 @@ class DayGuideControllerTest extends ControllerTest {
 	void 유효하지_않는_날짜로_하루_가이드를_조회하면_400을_반환한다() throws Exception {
 		//given
 
-		MultiValueMap<String, String> parms = new LinkedMultiValueMap<>();
-		parms.add("date", 유효하지_않은_날짜);
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("date", 유효하지_않은_날짜);
 		//when
-		ResultActions resultActions = get(mockMvc, URL, parms);
+		ResultActions resultActions = get(mockMvc, URL, params);
 		//then
 		resultActions.andExpectAll(
 			status().isBadRequest(),

--- a/src/test/java/com/coniverse/dangjang/domain/guide/common/service/DayGuideServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/common/service/DayGuideServiceTest.java
@@ -7,8 +7,11 @@ import static org.assertj.core.api.Assertions.*;
 import java.time.LocalDate;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -28,6 +31,7 @@ import com.coniverse.dangjang.support.annotation.WithDangjangUser;
  * @since 1.0.0
  */
 @WithDangjangUser
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest
 class DayGuideServiceTest {
@@ -63,6 +67,7 @@ class DayGuideServiceTest {
 		체중_가이드 = weightGuideRepository.save(체중_가이드(테오_아이디, 생성_날짜));
 	}
 
+	@Order(100)
 	@Test
 	void 하루_가이드를_성공적으로_조회한다() {
 		// given
@@ -72,11 +77,32 @@ class DayGuideServiceTest {
 		// then
 		assertThat(하루_가이드_응답.date()).isEqualTo(조회_날짜_Date);
 		assertThat(하루_가이드_응답.nickname()).isEqualTo(테오.getNickname());
-		assertThat(하루_가이드_응답.weight().weightDiff()).isEqualTo(체중_가이드.getWeightDiff());
+		assertThat(하루_가이드_응답.weight().title()).isEqualTo(체중_가이드.getContent());
 		assertThat(하루_가이드_응답.weight().bmi()).isEqualTo(체중_가이드.getBmi());
 		assertThat(하루_가이드_응답.weight().unit()).isEqualTo(체중_가이드.getUnit());
 		assertThat(하루_가이드_응답.bloodSugars()).hasSize(혈당_가이드.getTodayGuides().size());
 		assertThat(하루_가이드_응답.exercise().calorie()).isEqualTo(운동_칼로리);
 		assertThat(하루_가이드_응답.exercise().stepCount()).isEqualTo(운동_가이드.getStepCount());
+	}
+
+	@Order(200)
+	@Test
+	void 저장된_가이드가_없을때_에러를_반환하지_않는다() {
+		// given
+		exerciseGuideRepository.deleteAll();
+		bloodSugarGuideRepository.deleteAll();
+		weightGuideRepository.deleteAll();
+
+		// when
+		DayGuideResponse 하루_가이드_응답 = dayGuideService.getDayGuide(테오_아이디, 생성_날짜);
+		// then
+		assertThat(하루_가이드_응답.date()).isEqualTo(조회_날짜_Date);
+		assertThat(하루_가이드_응답.nickname()).isEqualTo(테오.getNickname());
+		assertThat(하루_가이드_응답.weight().title()).isBlank();
+		assertThat(하루_가이드_응답.weight().bmi()).isZero();
+		assertThat(하루_가이드_응답.weight().unit()).isBlank();
+		assertThat(하루_가이드_응답.bloodSugars()).hasSize(0);
+		assertThat(하루_가이드_응답.exercise().calorie()).isZero();
+		assertThat(하루_가이드_응답.exercise().stepCount()).isZero();
 	}
 }

--- a/src/test/java/com/coniverse/dangjang/domain/guide/common/service/DayGuideServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/common/service/DayGuideServiceTest.java
@@ -1,0 +1,82 @@
+package com.coniverse.dangjang.domain.guide.common.service;
+
+import static com.coniverse.dangjang.fixture.GuideFixture.*;
+import static com.coniverse.dangjang.fixture.UserFixture.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.coniverse.dangjang.domain.guide.bloodsugar.document.BloodSugarGuide;
+import com.coniverse.dangjang.domain.guide.bloodsugar.repository.BloodSugarGuideRepository;
+import com.coniverse.dangjang.domain.guide.common.dto.DayGuideResponse;
+import com.coniverse.dangjang.domain.guide.exercise.document.ExerciseGuide;
+import com.coniverse.dangjang.domain.guide.exercise.repository.ExerciseGuideRepository;
+import com.coniverse.dangjang.domain.guide.weight.document.WeightGuide;
+import com.coniverse.dangjang.domain.guide.weight.repository.WeightGuideRepository;
+import com.coniverse.dangjang.domain.user.entity.User;
+import com.coniverse.dangjang.domain.user.repository.UserRepository;
+import com.coniverse.dangjang.support.annotation.WithDangjangUser;
+
+/**
+ * @author EVE
+ * @since 1.0.0
+ */
+@WithDangjangUser
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest
+class DayGuideServiceTest {
+	@Autowired
+	private DayGuideService dayGuideService;
+	@Autowired
+	private ExerciseGuideRepository exerciseGuideRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private WeightGuideRepository weightGuideRepository;
+	@Autowired
+	private BloodSugarGuideRepository bloodSugarGuideRepository;
+	private User 테오;
+	private String 테오_아이디;
+	private String 생성_날짜 = "2023-12-31";
+	private LocalDate 생성_날짜_Date = LocalDate.parse(생성_날짜).plusDays(1);
+	private LocalDate 조회_날짜_Date = LocalDate.parse(생성_날짜);
+
+	private BloodSugarGuide 혈당_가이드;
+	private ExerciseGuide 운동_가이드;
+	private WeightGuide 체중_가이드;
+
+	@BeforeAll
+	void setUp() {
+		exerciseGuideRepository.deleteAll();
+		bloodSugarGuideRepository.deleteAll();
+		weightGuideRepository.deleteAll();
+		테오 = userRepository.save(유저_테오());
+		테오_아이디 = 테오.getOauthId();
+		운동_가이드 = exerciseGuideRepository.save(운동_가이드(테오_아이디, 생성_날짜_Date));
+		혈당_가이드 = bloodSugarGuideRepository.save(혈당_가이드_도큐먼트(테오_아이디, 생성_날짜));
+		체중_가이드 = weightGuideRepository.save(체중_가이드(테오_아이디, 생성_날짜));
+	}
+
+	@Test
+	void 하루_가이드를_성공적으로_조회한다() {
+		// given
+		int 운동_칼로리 = 운동_가이드.getExerciseCalories().stream().mapToInt(exerciseCalorie -> exerciseCalorie.calorie()).sum();
+		// when
+		DayGuideResponse 하루_가이드_응답 = dayGuideService.getDayGuide(테오_아이디, 생성_날짜);
+		// then
+		assertThat(하루_가이드_응답.date()).isEqualTo(조회_날짜_Date);
+		assertThat(하루_가이드_응답.nickname()).isEqualTo(테오.getNickname());
+		assertThat(하루_가이드_응답.weight().weightDiff()).isEqualTo(체중_가이드.getWeightDiff());
+		assertThat(하루_가이드_응답.weight().bmi()).isEqualTo(체중_가이드.getBmi());
+		assertThat(하루_가이드_응답.weight().unit()).isEqualTo(체중_가이드.getUnit());
+		assertThat(하루_가이드_응답.bloodSugars()).hasSize(혈당_가이드.getTodayGuides().size());
+		assertThat(하루_가이드_응답.exercise().calorie()).isEqualTo(운동_칼로리);
+		assertThat(하루_가이드_응답.exercise().stepCount()).isEqualTo(운동_가이드.getStepCount());
+	}
+}

--- a/src/test/java/com/coniverse/dangjang/domain/guide/common/service/DayGuideServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/common/service/DayGuideServiceTest.java
@@ -24,13 +24,11 @@ import com.coniverse.dangjang.domain.guide.weight.document.WeightGuide;
 import com.coniverse.dangjang.domain.guide.weight.repository.WeightGuideRepository;
 import com.coniverse.dangjang.domain.user.entity.User;
 import com.coniverse.dangjang.domain.user.repository.UserRepository;
-import com.coniverse.dangjang.support.annotation.WithDangjangUser;
 
 /**
  * @author EVE
  * @since 1.0.0
  */
-@WithDangjangUser
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest

--- a/src/test/java/com/coniverse/dangjang/domain/guide/common/service/DayGuideServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/common/service/DayGuideServiceTest.java
@@ -101,7 +101,7 @@ class DayGuideServiceTest {
 		assertThat(하루_가이드_응답.weight().title()).isBlank();
 		assertThat(하루_가이드_응답.weight().bmi()).isZero();
 		assertThat(하루_가이드_응답.weight().unit()).isBlank();
-		assertThat(하루_가이드_응답.bloodSugars()).hasSize(0);
+		assertThat(하루_가이드_응답.bloodSugars()).isEmpty();
 		assertThat(하루_가이드_응답.exercise().calorie()).isZero();
 		assertThat(하루_가이드_응답.exercise().stepCount()).isZero();
 	}

--- a/src/test/java/com/coniverse/dangjang/domain/guide/common/service/GuideServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/common/service/GuideServiceTest.java
@@ -1,4 +1,4 @@
-package com.coniverse.dangjang.domain.guide.common;
+package com.coniverse.dangjang.domain.guide.common.service;
 
 import static com.coniverse.dangjang.fixture.CommonCodeFixture.*;
 import static org.assertj.core.api.Assertions.*;
@@ -18,8 +18,6 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 
 import com.coniverse.dangjang.domain.code.enums.CommonCode;
 import com.coniverse.dangjang.domain.guide.bloodsugar.service.BloodSugarGuideGenerateService;
-import com.coniverse.dangjang.domain.guide.common.service.GuideGenerateService;
-import com.coniverse.dangjang.domain.guide.common.service.GuideService;
 import com.coniverse.dangjang.domain.guide.exercise.service.ExerciseGuideGenerateService;
 import com.coniverse.dangjang.domain.guide.weight.service.WeightGuideGenerateService;
 import com.coniverse.dangjang.fixture.AnalysisDataFixture;

--- a/src/test/java/com/coniverse/dangjang/domain/healthmetric/service/HealthMetricChartSearchServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/healthmetric/service/HealthMetricChartSearchServiceTest.java
@@ -99,7 +99,7 @@ class HealthMetricChartSearchServiceTest {
 			마지막_날짜);
 
 		// then
-		assertThat(healthMetricChartResponse.exerciseCalories()).hasSize(0);
+		assertThat(healthMetricChartResponse.exerciseCalories()).isEmpty();
 	}
 
 }

--- a/src/test/java/com/coniverse/dangjang/domain/healthmetric/service/HealthMetricChartSearchServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/healthmetric/service/HealthMetricChartSearchServiceTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
 
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -54,7 +54,7 @@ class HealthMetricChartSearchServiceTest {
 	@PersistenceContext
 	private EntityManager em;
 
-	@BeforeAll
+	@BeforeEach
 	void setUp() {
 		exerciseGuideRepository.deleteAll();
 		healthMetricRepository.deleteAll();
@@ -74,7 +74,7 @@ class HealthMetricChartSearchServiceTest {
 		exerciseGuideRepository.saveAll(운동가이드_리스트(테오, 생성_날짜, 200, 10));
 
 		// when
-		HealthMetricChartResponse healthMetricChartResponse = healthMetricChartSearchService.findHealthMetricChart(테오.getId(), 시작_날짜,
+		HealthMetricChartResponse healthMetricChartResponse = healthMetricChartSearchService.findHealthMetricChart(테오.getOauthId(), 시작_날짜,
 			마지막_날짜);
 
 		// then
@@ -82,6 +82,24 @@ class HealthMetricChartSearchServiceTest {
 		assertThat(healthMetricChartResponse.weights()).hasSize(7);
 		assertThat(healthMetricChartResponse.stepCounts()).hasSize(7);
 		assertThat(healthMetricChartResponse.exerciseCalories()).hasSize(7);
+	}
+
+	@Order(200)
+	@Transactional
+	@Test
+	void 칼로리가_0일때_제외하고_전달한다() {
+		// given
+		테오 = userRepository.save(유저_테오());
+		em.flush();
+
+		exerciseGuideRepository.save(걸음수_운동_가이드(테오.getOauthId(), 생성_날짜.plusDays(1)));
+
+		// when
+		HealthMetricChartResponse healthMetricChartResponse = healthMetricChartSearchService.findHealthMetricChart(테오.getOauthId(), 시작_날짜,
+			마지막_날짜);
+
+		// then
+		assertThat(healthMetricChartResponse.exerciseCalories()).hasSize(0);
 	}
 
 }

--- a/src/test/java/com/coniverse/dangjang/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/user/controller/UserControllerTest.java
@@ -18,7 +18,7 @@ import com.coniverse.dangjang.support.ControllerTest;
  * @since 1.0.0
  */
 class UserControllerTest extends ControllerTest {
-	private final String URI = "/api";
+	private static final String URI = "/api";
 
 	@Test
 	void 닉네임을_받아와_확인을_성공한다() throws Exception {

--- a/src/test/java/com/coniverse/dangjang/fixture/GuideFixture.java
+++ b/src/test/java/com/coniverse/dangjang/fixture/GuideFixture.java
@@ -86,6 +86,20 @@ public class GuideFixture {
 			.build();
 	}
 
+	public static ExerciseGuide 걸음수_운동_가이드(String oauthId, LocalDate 조회_날짜) {
+		List<ExerciseCalorie> exerciseCalories = List.of(new ExerciseCalorie(CommonCode.HEALTH, 0, 60), new ExerciseCalorie(CommonCode.RUN, 0, 120));
+
+		return ExerciseGuide.builder()
+			.oauthId(oauthId)
+			.needStepByLastWeek(0)
+			.comparedToLastWeek("저번주 대비 가이드입니다.")
+			.content("가이드 내용입니다.")
+			.createdAt(조회_날짜)
+			.stepCount(10000)
+			.exerciseCalories(exerciseCalories)
+			.build();
+	}
+
 	public static BloodSugarGuideResponse 혈당_가이드_응답(String createdAt) {
 		List<TodayGuide> 오늘의_가이드 = 혈당_오늘의_가이드(createdAt);
 		List<SubGuideResponse> 서브_가이드 = new ArrayList<>();
@@ -143,7 +157,7 @@ public class GuideFixture {
 	}
 
 	public static WeightDayGuide 체중_하루_가이드() {
-		return new WeightDayGuide("70", 18.89, 10);
+		return new WeightDayGuide("70", 18.89, "정상이에요! 표준 체중보다 1kg 많아요");
 	}
 
 	public static ExerciseDayGuide 운동_하루_가이드() {

--- a/src/test/java/com/coniverse/dangjang/fixture/GuideFixture.java
+++ b/src/test/java/com/coniverse/dangjang/fixture/GuideFixture.java
@@ -16,11 +16,14 @@ import com.coniverse.dangjang.domain.guide.bloodsugar.document.SubGuide;
 import com.coniverse.dangjang.domain.guide.bloodsugar.document.TodayGuide;
 import com.coniverse.dangjang.domain.guide.bloodsugar.dto.BloodSugarGuideResponse;
 import com.coniverse.dangjang.domain.guide.bloodsugar.dto.SubGuideResponse;
+import com.coniverse.dangjang.domain.guide.common.dto.DayGuideResponse;
 import com.coniverse.dangjang.domain.guide.common.dto.GuideResponse;
 import com.coniverse.dangjang.domain.guide.exercise.document.ExerciseCalorie;
 import com.coniverse.dangjang.domain.guide.exercise.document.ExerciseGuide;
+import com.coniverse.dangjang.domain.guide.exercise.dto.ExerciseDayGuide;
 import com.coniverse.dangjang.domain.guide.exercise.dto.ExerciseGuideResponse;
 import com.coniverse.dangjang.domain.guide.weight.document.WeightGuide;
+import com.coniverse.dangjang.domain.guide.weight.dto.WeightDayGuide;
 import com.coniverse.dangjang.domain.guide.weight.dto.WeightGuideResponse;
 import com.coniverse.dangjang.domain.user.entity.User;
 
@@ -133,6 +136,18 @@ public class GuideFixture {
 				.createdAt(createdAt.plusDays(n))
 				.build()).collect(Collectors.toList());
 
+	}
+
+	public static DayGuideResponse 하루_가이드_응답(String nickname, LocalDate date, List<TodayGuide> 혈당가이드, WeightDayGuide 체중가이드, ExerciseDayGuide 운동가이드) {
+		return new DayGuideResponse(nickname, date, 혈당가이드, 체중가이드, 운동가이드, false);
+	}
+
+	public static WeightDayGuide 체중_하루_가이드() {
+		return new WeightDayGuide("70", 18.89, 10);
+	}
+
+	public static ExerciseDayGuide 운동_하루_가이드() {
+		return new ExerciseDayGuide(1400, 11000);
 	}
 
 }

--- a/src/test/java/com/coniverse/dangjang/support/ControllerTest.java
+++ b/src/test/java/com/coniverse/dangjang/support/ControllerTest.java
@@ -13,6 +13,8 @@ import com.coniverse.dangjang.domain.auth.service.JwtTokenProvider;
 import com.coniverse.dangjang.domain.auth.service.OauthLoginService;
 import com.coniverse.dangjang.domain.guide.bloodsugar.controller.BloodSugarGuideController;
 import com.coniverse.dangjang.domain.guide.bloodsugar.service.BloodSugarGuideSearchService;
+import com.coniverse.dangjang.domain.guide.common.controller.GuideController;
+import com.coniverse.dangjang.domain.guide.common.service.DayGuideService;
 import com.coniverse.dangjang.domain.guide.exercise.controller.ExerciseGuideController;
 import com.coniverse.dangjang.domain.guide.exercise.service.ExerciseGuideSearchService;
 import com.coniverse.dangjang.domain.guide.weight.controller.WeightGuideController;
@@ -48,7 +50,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 		WeightGuideController.class,
 		ExerciseGuideController.class,
 		BloodSugarGuideController.class,
-		HealthConnectController.class
+		HealthConnectController.class,
+		GuideController.class
 	},
 	includeFilters = @ComponentScan.Filter(classes = {EnableWebSecurity.class}))
 @ComponentScan(basePackages = "com.coniverse.dangjang.domain.auth.handler")
@@ -78,4 +81,6 @@ public class ControllerTest {
 	private HealthConnectRegisterService healthConnectRegisterService;
 	@MockBean
 	private HealthMetricChartSearchService healthMetricChartSearchService;
+	@MockBean
+	private DayGuideService dayGuideService;
 }


### PR DESCRIPTION
# Changes 📝
- 하루 요약 가이드 조회 API 구현

## Details 🌼
홈에 필요한 하루 요약 가이드 조회 API를 구현하였습니다.
하루 요약 가이드 중 혈당은 TodayGuides, 체중은 체중값,BMI,평균 체중대비 격차 , 운동은 총 소모칼로리와 걸음수가 필요합니다.
각각의 가이드에서 조회하고 정리하여 전달합니다.
`/api/guide?date={날짜}` 엔드포인트로 요청하면 `DayGuideResponse`로 전달합니다.

```
{
    "success": true,
    "errorCode": 0,
    "message": "OK",
    "data": {
        "nickname": "TEO",
        "date": "2023-12-31",
        "bloodSugars": [
            {
                "alert": "저혈당",
                "count": 0
            },
            {
                "alert": "저혈당 의심",
                "count": 0
            },
            {
                "alert": "정상",
                "count": 1
            },
            {
                "alert": "주의",
                "count": 0
            },
            {
                "alert": "경고",
                "count": 0
            }
        ],
        "weight": {
            "unit": "50",
            "bmi": 15.43,
            "title": "저체중이에요. 평균 체중에 비해 -21kg 적어요"
        },
        "exercise": {
            "calorie": 0,
            "stepCount": 100000
        },
        "notification": false
    }
}
```

## Check List ☑️
- [x] 테스트 코드를 통과했다.
- [x] merge할 브랜치의 위치를 확인했다. (main ❌)
- [x] Assignee를 지정했다.
- [x] Label을 지정했다.


