### PR TITLE
건강지표 삭제 기능 구현

### DIFF
--- a/src/main/java/com/coniverse/dangjang/domain/guide/bloodsugar/document/BloodSugarGuide.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/bloodsugar/document/BloodSugarGuide.java
@@ -166,4 +166,16 @@ public class BloodSugarGuide {
 			.findFirst()
 			.ifPresent(TodayGuide::minusCount);
 	}
+
+	/**
+	 * 서브 가이드를 삭제한다.
+	 *
+	 * @param type 서브 가이드 타입
+	 * @since 1.3.0
+	 */
+	public void removeSubGuide(CommonCode type) {
+		SubGuide subGuide = getSubGuide(type);
+		this.subGuides.remove(subGuide);
+		minusAlertCount(subGuide.getAlert());
+	}
 }

--- a/src/main/java/com/coniverse/dangjang/domain/guide/bloodsugar/document/BloodSugarGuide.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/bloodsugar/document/BloodSugarGuide.java
@@ -178,4 +178,14 @@ public class BloodSugarGuide {
 		this.subGuides.remove(subGuide);
 		minusAlertCount(subGuide.getAlert());
 	}
+
+	/**
+	 * 서브 가이드가 존재하는지 확인한다.
+	 *
+	 * @return 서브 가이드가 존재하면 true, 존재하지 않으면 false
+	 * @since 1.3.0
+	 */
+	public boolean existsSubGuide() {
+		return !this.subGuides.isEmpty();
+	}
 }

--- a/src/main/java/com/coniverse/dangjang/domain/guide/bloodsugar/service/BloodSugarGuideGenerateService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/bloodsugar/service/BloodSugarGuideGenerateService.java
@@ -36,8 +36,6 @@ public class BloodSugarGuideGenerateService implements GuideGenerateService {
 
 	/**
 	 * 서브 가이드를 생성해서 혈당 가이드에 저장한다.
-	 * <p>
-	 * 혈당 가이드가 존재하면 새로운 서브 가이드를 추가하고, 존재하지 않으면 혈당 가이드를 생성하여 서브 가이드를 추가한다.
 	 *
 	 * @param analysisData 혈당 분석 데이터
 	 * @return 서브 가이드 응답
@@ -46,17 +44,27 @@ public class BloodSugarGuideGenerateService implements GuideGenerateService {
 	@Override
 	public GuideResponse createGuide(AnalysisData analysisData) {
 		BloodSugarAnalysisData data = (BloodSugarAnalysisData)analysisData;
-		BloodSugarGuide guide;
-		try {
-			guide = bloodSugarGuideSearchService.findByUserIdAndCreatedAt(data.getOauthId(), data.getCreatedAt());
-		} catch (GuideNotFoundException e) {
-			guide = mapper.toDocument(data);
-		}
+		BloodSugarGuide guide = getGuide(data);
 		GuideFormat guideFormat = bloodSugarGuideFormatFactory.createGuideFormat(data);
 		SubGuide subGuide = mapper.toSubGuide(data, guideFormat);
 		guide.addSubGuide(subGuide);
 		bloodSugarGuideRepository.save(guide);
 		return mapper.toSubGuideResponse(subGuide, guide.getTodayGuides());
+	}
+
+	/**
+	 * 혈당 가이드가 존재하면 그대로 반환하고, 존재하지 않으면 새로 생성해서 반환한다.
+	 *
+	 * @param data 혈당 분석 데이터
+	 * @return 혈당 가이드
+	 * @since 1.3.0
+	 */
+	private BloodSugarGuide getGuide(BloodSugarAnalysisData data) {
+		try {
+			return bloodSugarGuideSearchService.findByUserIdAndCreatedAt(data.getOauthId(), data.getCreatedAt());
+		} catch (GuideNotFoundException e) {
+			return mapper.toDocument(data);
+		}
 	}
 
 	/**

--- a/src/main/java/com/coniverse/dangjang/domain/guide/bloodsugar/service/BloodSugarGuideGenerateService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/bloodsugar/service/BloodSugarGuideGenerateService.java
@@ -99,6 +99,14 @@ public class BloodSugarGuideGenerateService implements GuideGenerateService {
 		return mapper.toSubGuideResponse(subGuide, guide.getTodayGuides());
 	}
 
+	/**
+	 * 서브 가이드를 삭제한다. 서브 가이드가 존재하지 않으면 혈당 가이드를 삭제한다.
+	 *
+	 * @param oauthId   유저 PK
+	 * @param createdAt 생성일자
+	 * @param type      타입
+	 * @since 1.3.0
+	 */
 	@Override
 	public void removeGuide(String oauthId, LocalDate createdAt, CommonCode type) {
 		BloodSugarGuide guide = bloodSugarGuideSearchService.findByUserIdAndCreatedAt(oauthId, createdAt);

--- a/src/main/java/com/coniverse/dangjang/domain/guide/bloodsugar/service/BloodSugarGuideGenerateService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/bloodsugar/service/BloodSugarGuideGenerateService.java
@@ -1,5 +1,7 @@
 package com.coniverse.dangjang.domain.guide.bloodsugar.service;
 
+import java.time.LocalDate;
+
 import org.springframework.stereotype.Service;
 
 import com.coniverse.dangjang.domain.analysis.dto.AnalysisData;
@@ -95,6 +97,17 @@ public class BloodSugarGuideGenerateService implements GuideGenerateService {
 		guide.updateSubGuide(subGuide, prevType);
 		bloodSugarGuideRepository.save(guide);
 		return mapper.toSubGuideResponse(subGuide, guide.getTodayGuides());
+	}
+
+	@Override
+	public void removeGuide(String oauthId, LocalDate createdAt, CommonCode type) {
+		BloodSugarGuide guide = bloodSugarGuideSearchService.findByUserIdAndCreatedAt(oauthId, createdAt);
+		guide.removeSubGuide(type);
+		if (guide.existsSubGuide()) {
+			bloodSugarGuideRepository.save(guide);
+			return;
+		}
+		bloodSugarGuideRepository.delete(guide);
 	}
 
 	@Override

--- a/src/main/java/com/coniverse/dangjang/domain/guide/common/service/GuideGenerateService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/common/service/GuideGenerateService.java
@@ -1,5 +1,7 @@
 package com.coniverse.dangjang.domain.guide.common.service;
 
+import java.time.LocalDate;
+
 import com.coniverse.dangjang.domain.analysis.dto.AnalysisData;
 import com.coniverse.dangjang.domain.code.enums.CommonCode;
 import com.coniverse.dangjang.domain.code.enums.GroupCode;
@@ -19,6 +21,8 @@ public interface GuideGenerateService {
 	default GuideResponse updateGuideWithType(AnalysisData analysisData, CommonCode prevType) {
 		throw new UnsupportedOperationException("잘못된 메서드 호출입니다.");
 	}
+
+	void removeGuide(String oauthId, LocalDate createdAt, CommonCode type);
 
 	GroupCode getGroupCode();
 }

--- a/src/main/java/com/coniverse/dangjang/domain/guide/common/service/GuideService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/common/service/GuideService.java
@@ -1,5 +1,6 @@
 package com.coniverse.dangjang.domain.guide.common.service;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -69,5 +70,11 @@ public class GuideService {
 	 */
 	private GuideGenerateService findGuideGenerateService(GroupCode groupCode) {
 		return guideGenerateServiceMap.get(groupCode);
+	}
+
+	public void removeGuide(String oauthId, LocalDate createdAt, CommonCode type) {
+		GroupCode groupCode = GroupCode.findByCode(type);
+		GuideGenerateService guideGenerateService = findGuideGenerateService(groupCode);
+		guideGenerateService.removeGuide(oauthId, createdAt, type);
 	}
 }

--- a/src/main/java/com/coniverse/dangjang/domain/guide/common/service/GuideService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/common/service/GuideService.java
@@ -35,8 +35,7 @@ public class GuideService {
 	 * @since 1.0.0
 	 */
 	public GuideResponse createGuide(AnalysisData analysisData) {
-		GroupCode groupCode = GroupCode.findByCode(analysisData.getType());
-		GuideGenerateService guideGenerateService = findGuideGenerateService(groupCode);
+		GuideGenerateService guideGenerateService = findGuideGenerateService(analysisData.getType());
 		return guideGenerateService.createGuide(analysisData);
 	}
 
@@ -46,8 +45,7 @@ public class GuideService {
 	 * @since 1.0.0
 	 */
 	public GuideResponse updateGuide(AnalysisData analysisData) {
-		GroupCode groupCode = GroupCode.findByCode(analysisData.getType());
-		GuideGenerateService guideGenerateService = findGuideGenerateService(groupCode);
+		GuideGenerateService guideGenerateService = findGuideGenerateService(analysisData.getType());
 		return guideGenerateService.updateGuide(analysisData);
 	}
 
@@ -57,9 +55,18 @@ public class GuideService {
 	 * @since 1.0.0
 	 */
 	public GuideResponse updateGuideWithType(AnalysisData analysisData, CommonCode prevType) {
-		GroupCode groupCode = GroupCode.findByCode(analysisData.getType());
-		GuideGenerateService guideGenerateService = findGuideGenerateService(groupCode);
+		GuideGenerateService guideGenerateService = findGuideGenerateService(analysisData.getType());
 		return guideGenerateService.updateGuideWithType(analysisData, prevType);
+	}
+
+	/**
+	 * 가이드를 삭제한다.
+	 *
+	 * @since 1.3.0
+	 */
+	public void removeGuide(String oauthId, LocalDate createdAt, CommonCode type) {
+		GuideGenerateService guideGenerateService = findGuideGenerateService(type);
+		guideGenerateService.removeGuide(oauthId, createdAt, type);
 	}
 
 	/**
@@ -68,13 +75,8 @@ public class GuideService {
 	 * @see GroupCode
 	 * @since 1.0.0
 	 */
-	private GuideGenerateService findGuideGenerateService(GroupCode groupCode) {
-		return guideGenerateServiceMap.get(groupCode);
-	}
-
-	public void removeGuide(String oauthId, LocalDate createdAt, CommonCode type) {
+	private GuideGenerateService findGuideGenerateService(CommonCode type) {
 		GroupCode groupCode = GroupCode.findByCode(type);
-		GuideGenerateService guideGenerateService = findGuideGenerateService(groupCode);
-		guideGenerateService.removeGuide(oauthId, createdAt, type);
+		return guideGenerateServiceMap.get(groupCode);
 	}
 }

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/document/ExerciseGuide.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/document/ExerciseGuide.java
@@ -69,15 +69,12 @@ public class ExerciseGuide { // TODO 걸음 가이드, 칼로리 가이드로 �
 	 * <p>
 	 * 기존에 존재하는 운동 칼로리를 삭제하고, 새로운 운동 칼로리를 추가한다.
 	 *
-	 * @param updateExerciseCalorie 운동칼로리 객체
+	 * @param updatedExerciseCalorie 운동칼로리 객체
 	 * @since 1.0.0
 	 */
-	public void changeExerciseCalories(ExerciseCalorie updateExerciseCalorie) {
-		exerciseCalories.stream()
-			.filter(existExerciseCalorie -> existExerciseCalorie.type().equals(updateExerciseCalorie.type()))
-			.findFirst()
-			.ifPresent(existExerciseCalorie -> exerciseCalories.remove(existExerciseCalorie));
-		exerciseCalories.add(updateExerciseCalorie);
+	public void changeExerciseCalories(ExerciseCalorie updatedExerciseCalorie) {
+		removeExerciseCalorie(updatedExerciseCalorie.type());
+		exerciseCalories.add(updatedExerciseCalorie);
 	}
 
 	/**

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/document/ExerciseGuide.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/document/ExerciseGuide.java
@@ -6,11 +6,12 @@ import java.util.List;
 
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import com.coniverse.dangjang.domain.code.enums.CommonCode;
+
 import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 /**
  * 운동 가이드 Document
@@ -18,15 +19,14 @@ import lombok.Setter;
  * @author EVE
  * @since 1.0.0
  */
-@Setter
 @Getter
 @Document
 @NoArgsConstructor
-public class ExerciseGuide {
+public class ExerciseGuide { // TODO 걸음 가이드, 칼로리 가이드로 분리해서 리팩토링
 	@Id
 	private String id;
 	private String oauthId;
-	private int needStepByTTS;
+	private int needStepByTTS; // TODO 걸음 수 관련 필드 -> 객체로 묶기
 	private int needStepByLastWeek;
 	private LocalDate createdAt;
 	private String content;
@@ -78,5 +78,18 @@ public class ExerciseGuide {
 			.findFirst()
 			.ifPresent(existExerciseCalorie -> exerciseCalories.remove(existExerciseCalorie));
 		exerciseCalories.add(updateExerciseCalorie);
+	}
+
+	/**
+	 * 운동 칼로리를 삭제한다.
+	 *
+	 * @param type 운동 타입
+	 * @since 1.3.0
+	 */
+	public void removeExerciseCalorie(CommonCode type) {
+		exerciseCalories.stream()
+			.filter(exerciseCalorie -> exerciseCalorie.type().equals(type))
+			.findFirst()
+			.ifPresent(exerciseCalorie -> exerciseCalories.remove(exerciseCalorie));
 	}
 }

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateService.java
@@ -1,5 +1,6 @@
 package com.coniverse.dangjang.domain.guide.exercise.service;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -27,7 +28,7 @@ import lombok.RequiredArgsConstructor;
  */
 @Service
 @RequiredArgsConstructor
-public class ExerciseGuideGenerateService implements GuideGenerateService {
+public class ExerciseGuideGenerateService implements GuideGenerateService { // TODO 리팩토링 필수
 	private final ExerciseGuideSearchService exerciseGuideSearchService;
 	private final ExerciseGuideMapper exerciseGuideMapper;
 	private final ExerciseGuideRepository exerciseGuideRepository;
@@ -104,6 +105,36 @@ public class ExerciseGuideGenerateService implements GuideGenerateService {
 			exerciseAnalysisData.getUnit());
 		updateExerciseGuide.changeExerciseCalories(exerciseCalorie);
 		return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(updateExerciseGuide));
+	}
+
+	/**
+	 * 걸음 수 가이드 또는 칼로리 가이드를 삭제한다.
+	 *
+	 * @since 1.3.0
+	 */
+	@Override
+	public void removeGuide(String oauthId, LocalDate createdAt, CommonCode type) {
+		ExerciseGuide exerciseGuide = exerciseGuideSearchService.findByOauthIdAndCreatedAt(oauthId, createdAt);
+		if (type.equals(CommonCode.STEP_COUNT)) {
+			exerciseGuide.changeAboutWalk(0, 0, null, null, 0);
+			removeEmptyExerciseGuide(exerciseGuide);
+			return;
+		}
+		exerciseGuide.removeExerciseCalorie(type);
+		removeEmptyExerciseGuide(exerciseGuide);
+	}
+
+	/**
+	 * 운동 가이드가 비어있으면 삭제한다.
+	 *
+	 * @since 1.3.0
+	 */
+	private void removeEmptyExerciseGuide(ExerciseGuide exerciseGuide) {
+		if (exerciseGuide.getContent() == null && exerciseGuide.getExerciseCalories().isEmpty()) {
+			exerciseGuideRepository.delete(exerciseGuide);
+			return;
+		}
+		exerciseGuideRepository.save(exerciseGuide);
 	}
 
 	@Override

--- a/src/main/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideGenerateService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideGenerateService.java
@@ -1,10 +1,13 @@
 package com.coniverse.dangjang.domain.guide.weight.service;
 
+import java.time.LocalDate;
+
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.stereotype.Service;
 
 import com.coniverse.dangjang.domain.analysis.dto.AnalysisData;
 import com.coniverse.dangjang.domain.analysis.dto.healthMetric.WeightAnalysisData;
+import com.coniverse.dangjang.domain.code.enums.CommonCode;
 import com.coniverse.dangjang.domain.code.enums.GroupCode;
 import com.coniverse.dangjang.domain.guide.common.dto.response.GuideResponse;
 import com.coniverse.dangjang.domain.guide.common.service.GuideGenerateService;
@@ -57,6 +60,20 @@ public class WeightGuideGenerateService implements GuideGenerateService {
 		String content = createContent(data);
 		weightGuide.changeAboutWeight(data.getWeightDiff(), data.getAlert(), content, data.getBmi(), String.valueOf(data.getUnit()));
 		return weightMapper.toResponse(weightGuideRepository.save(weightGuide));
+	}
+
+	/**
+	 * 체중 가이드를 삭제한다.
+	 *
+	 * @param oauthId   유저 PK
+	 * @param createdAt 생성일자
+	 * @param type      타입
+	 * @since 1.3.0
+	 */
+	@Override
+	public void removeGuide(String oauthId, LocalDate createdAt, CommonCode type) {
+		WeightGuide weightGuide = weightGuideSearchService.findByUserIdAndCreatedAt(oauthId, createdAt.toString());
+		weightGuideRepository.delete(weightGuide);
 	}
 
 	@Override

--- a/src/main/java/com/coniverse/dangjang/domain/healthmetric/controller/HealthMetricController.java
+++ b/src/main/java/com/coniverse/dangjang/domain/healthmetric/controller/HealthMetricController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,6 +29,7 @@ import com.coniverse.dangjang.global.dto.SuccessSingleResponse;
 import com.coniverse.dangjang.global.validator.ValidLocalDate;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -96,11 +98,26 @@ public class HealthMetricController {
 	 * @return 유저의 마지막 건강지표 생성일
 	 * @since 1.1.0
 	 */
-
 	@GetMapping("/last-date")
 	public ResponseEntity<SuccessSingleResponse<HealthMetricLastDateResponse>> getHealthMetricLastDate(@AuthenticationPrincipal User principal) {
 		String oauthId = principal.getUsername();
 		HealthMetricLastDateResponse response = healthMetricSearchService.findHealthMetricLastDate(oauthId);
 		return ResponseEntity.ok(new SuccessSingleResponse<>(HttpStatus.OK.getReasonPhrase(), response));
+	}
+
+	/**
+	 * 건강지표를 DELETE 요청한다.
+	 *
+	 * @param date      건강지표 생성일
+	 * @param type      건강지표 타입
+	 * @param principal 유저 정보
+	 * @return 성공 메시지
+	 * @since 1.3.0
+	 */
+	@DeleteMapping
+	public ResponseEntity<SuccessSingleResponse<?>> deleteHealthMetric(@ValidLocalDate @RequestParam String date, @NotBlank @RequestParam String type,
+		@AuthenticationPrincipal User principal) {
+		healthMetricRegisterService.remove(date, type, principal.getUsername());
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/coniverse/dangjang/domain/healthmetric/service/HealthMetricRegisterService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/healthmetric/service/HealthMetricRegisterService.java
@@ -115,5 +115,6 @@ public class HealthMetricRegisterService {
 		LocalDate createdAt = LocalDate.parse(date);
 		HealthMetric healthMetric = healthMetricSearchService.findByHealthMetricId(oauthId, createdAt, type);
 		healthMetricRepository.delete(healthMetric);
+		guideService.removeGuide(oauthId, createdAt, type);
 	}
 }

--- a/src/main/java/com/coniverse/dangjang/domain/healthmetric/service/HealthMetricRegisterService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/healthmetric/service/HealthMetricRegisterService.java
@@ -47,7 +47,7 @@ public class HealthMetricRegisterService {
 	 */
 	public HealthMetricResponse register(HealthMetricPostRequest request, String oauthId) {
 		final User user = userSearchService.findUserByOauthId(oauthId);
-		final HealthMetric healthMetric = healthMetricRepository.save(mapper.toEntity(request, user)); // TODO 가이드보다 insert 쿼리가 먼저 가도록 수정
+		final HealthMetric healthMetric = healthMetricRepository.save(mapper.toEntity(request, user));
 		final GuideResponse guideResponse = guideService.createGuide(analysisService.analyze(healthMetric));
 		return mapper.toResponse(healthMetric, guideResponse);
 	}
@@ -100,5 +100,20 @@ public class HealthMetricRegisterService {
 		final HealthMetric healthMetric = healthMetricRepository.save(mapper.toEntity(request, user));
 		final GuideResponse guideResponse = guideService.updateGuideWithType(analysisService.analyze(healthMetric), prevHealthMetric.getType());
 		return mapper.toResponse(healthMetric, guideResponse);
+	}
+
+	/**
+	 * 건강지표를 삭제한다.
+	 *
+	 * @param date        건강지표 생성일
+	 * @param requestType 건강지표 타입
+	 * @param oauthId     건강지표 삭제 유저 PK
+	 * @since 1.3.0
+	 */
+	public void remove(String date, String requestType, String oauthId) {
+		CommonCode type = EnumFindUtil.findByTitle(CommonCode.class, requestType);
+		LocalDate createdAt = LocalDate.parse(date);
+		HealthMetric healthMetric = healthMetricSearchService.findByHealthMetricId(oauthId, createdAt, type);
+		healthMetricRepository.delete(healthMetric);
 	}
 }

--- a/src/test/java/com/coniverse/dangjang/domain/guide/bloodsugar/service/BloodSugarGuideGenerateServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/bloodsugar/service/BloodSugarGuideGenerateServiceTest.java
@@ -240,7 +240,7 @@ class BloodSugarGuideGenerateServiceTest {
 
 		// then
 		BloodSugarGuide 삭제한_가이드 = bloodSugarGuideRepository.findByOauthIdAndCreatedAt(oauthId, createdAt).orElseThrow();
-		assertThat(삭제한_가이드.getSubGuides().size()).isEqualTo(혈당_가이드.getSubGuides().size() - 1);
+		assertThat(삭제한_가이드.getSubGuides()).hasSize(혈당_가이드.getSubGuides().size() - 1);
 	}
 
 	@Test

--- a/src/test/java/com/coniverse/dangjang/domain/guide/bloodsugar/service/BloodSugarGuideGenerateServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/bloodsugar/service/BloodSugarGuideGenerateServiceTest.java
@@ -1,9 +1,13 @@
 package com.coniverse.dangjang.domain.guide.bloodsugar.service;
 
 import static com.coniverse.dangjang.fixture.AnalysisDataFixture.*;
+import static com.coniverse.dangjang.fixture.CommonCodeFixture.*;
+import static com.coniverse.dangjang.fixture.GuideFixture.*;
 import static com.coniverse.dangjang.fixture.UserFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
 
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -19,6 +23,7 @@ import com.coniverse.dangjang.domain.code.enums.CommonCode;
 import com.coniverse.dangjang.domain.guide.bloodsugar.document.BloodSugarGuide;
 import com.coniverse.dangjang.domain.guide.bloodsugar.document.SubGuide;
 import com.coniverse.dangjang.domain.guide.bloodsugar.dto.SubGuideResponse;
+import com.coniverse.dangjang.domain.guide.bloodsugar.repository.BloodSugarGuideRepository;
 import com.coniverse.dangjang.domain.guide.common.exception.GuideAlreadyExistsException;
 import com.coniverse.dangjang.domain.guide.common.exception.GuideNotFoundException;
 import com.coniverse.dangjang.domain.user.entity.User;
@@ -38,6 +43,8 @@ class BloodSugarGuideGenerateServiceTest {
 	private BloodSugarAnalysisStrategy bloodSugarAnalysisStrategy;
 	@Autowired
 	private BloodSugarGuideSearchService bloodSugarGuideSearchService;
+	@Autowired
+	private BloodSugarGuideRepository bloodSugarGuideRepository;
 
 	@Order(100)
 	@Test
@@ -217,5 +224,37 @@ class BloodSugarGuideGenerateServiceTest {
 				assertThat(서브_가이드.getType()).isEqualTo(CommonCode.EMPTY_STOMACH);
 			}
 		);
+	}
+
+	@Test
+	void 서브_가이드를_정상적으로_삭제한다() {
+		// given
+		String oauthId = user.getOauthId();
+		String createdAt = "2021-08-01";
+		CommonCode type = CommonCode.BEFORE_BREAKFAST;
+		BloodSugarGuide 혈당_가이드 = 혈당_가이드_도큐먼트(oauthId, createdAt);
+		bloodSugarGuideRepository.save(혈당_가이드);
+
+		// when
+		bloodSugarGuideGenerateService.removeGuide(oauthId, LocalDate.parse(createdAt), type);
+
+		// then
+		BloodSugarGuide 삭제한_가이드 = bloodSugarGuideRepository.findByOauthIdAndCreatedAt(oauthId, createdAt).orElseThrow();
+		assertThat(삭제한_가이드.getSubGuides().size()).isEqualTo(혈당_가이드.getSubGuides().size() - 1);
+	}
+
+	@Test
+	void 서브_가이드를_모두_삭제하면_혈당_가이드도_삭제된다() {
+		// given
+		String oauthId = user.getOauthId();
+		String createdAt = "2021-08-01";
+		BloodSugarGuide 혈당_가이드 = 혈당_가이드_도큐먼트(oauthId, createdAt);
+		bloodSugarGuideRepository.save(혈당_가이드);
+
+		// when
+		혈당_타입().forEach(type -> bloodSugarGuideGenerateService.removeGuide(oauthId, LocalDate.parse(createdAt), type));
+
+		// then
+		assertThat(bloodSugarGuideRepository.findByOauthIdAndCreatedAt(oauthId, createdAt)).isEmpty();
 	}
 }

--- a/src/test/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateServiceTest.java
@@ -5,6 +5,7 @@ import static com.coniverse.dangjang.fixture.GuideFixture.*;
 import static com.coniverse.dangjang.fixture.HealthMetricFixture.*;
 import static com.coniverse.dangjang.fixture.UserFixture.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
@@ -15,6 +16,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -180,6 +182,45 @@ class ExerciseGuideGenerateServiceTest {
 				break;
 			}
 		}
+	}
 
+	@Test
+	void 걸음_가이드를_성공적으로_삭제한다() {
+		// given
+		String oauthId = user.getOauthId();
+		LocalDate createdAt = LocalDate.parse("2021-08-02");
+		CommonCode type = CommonCode.STEP_COUNT;
+		ExerciseGuide 운동_가이드 = 걸음수_운동_가이드(oauthId, createdAt);
+		exerciseGuideRepository.save(운동_가이드);
+
+		// when
+		exerciseGuideGenerateService.removeGuide(oauthId, createdAt.minusDays(1), type);
+
+		// then
+		ExerciseGuide 삭제한_가이드 = exerciseGuideRepository.findByOauthIdAndCreatedAt(oauthId, createdAt).orElseThrow();
+		assertAll(
+			() -> assertThat(삭제한_가이드.getContent()).isNull(),
+			() -> assertThat(삭제한_가이드.getComparedToLastWeek()).isNull(),
+			() -> assertThat(삭제한_가이드.getNeedStepByLastWeek()).isEqualTo(0),
+			() -> assertThat(삭제한_가이드.getNeedStepByTTS()).isEqualTo(0),
+			() -> assertThat(삭제한_가이드.getStepCount()).isEqualTo(0)
+		);
+	}
+
+	@Test
+	void 소모칼로리_가이드를_성공적으로_삭제한다() {
+		// given
+		String oauthId = user.getOauthId();
+		LocalDate createdAt = LocalDate.parse("2021-08-02");
+		CommonCode type = CommonCode.HEALTH;
+		ExerciseGuide 운동_가이드 = 운동_가이드(oauthId, createdAt);
+		exerciseGuideRepository.save(운동_가이드);
+
+		// when
+		exerciseGuideGenerateService.removeGuide(oauthId, createdAt.minusDays(1), type);
+
+		// then
+		ExerciseGuide 삭제한_가이드 = exerciseGuideRepository.findByOauthIdAndCreatedAt(oauthId, createdAt).orElseThrow();
+		assertThat(삭제한_가이드.getExerciseCalories()).hasSize(운동_가이드.getExerciseCalories().size() - 1);
 	}
 }

--- a/src/test/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateServiceTest.java
@@ -211,7 +211,7 @@ class ExerciseGuideGenerateServiceTest {
 	void 소모칼로리_가이드를_성공적으로_삭제한다() {
 		// given
 		String oauthId = user.getOauthId();
-		LocalDate createdAt = LocalDate.parse("2021-08-02");
+		LocalDate createdAt = LocalDate.parse("2021-08-03");
 		CommonCode type = CommonCode.HEALTH;
 		ExerciseGuide 운동_가이드 = 운동_가이드(oauthId, createdAt);
 		exerciseGuideRepository.save(운동_가이드);
@@ -222,5 +222,22 @@ class ExerciseGuideGenerateServiceTest {
 		// then
 		ExerciseGuide 삭제한_가이드 = exerciseGuideRepository.findByOauthIdAndCreatedAt(oauthId, createdAt).orElseThrow();
 		assertThat(삭제한_가이드.getExerciseCalories()).hasSize(운동_가이드.getExerciseCalories().size() - 1);
+	}
+
+	@Test
+	void 걸음수_소모칼로리_가이드가_존재하지_않으면_운동_가이드를_성공적으로_삭제한다() {
+		// given
+		String oauthId = user.getOauthId();
+		LocalDate createdAt = LocalDate.parse("2021-08-04");
+		ExerciseGuide 운동_가이드 = 걸음수_운동_가이드(oauthId, createdAt);
+		exerciseGuideRepository.save(운동_가이드);
+
+		// when
+		List.of(CommonCode.STEP_COUNT, CommonCode.HEALTH, CommonCode.RUN)
+			.forEach(type -> exerciseGuideGenerateService.removeGuide(oauthId, createdAt.minusDays(1), type));
+
+		// then
+		assertThatThrownBy(() -> exerciseGuideSearchService.findByOauthIdAndCreatedAt(oauthId, createdAt))
+			.isInstanceOf(GuideNotFoundException.class);
 	}
 }

--- a/src/test/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateServiceTest.java
@@ -201,9 +201,9 @@ class ExerciseGuideGenerateServiceTest {
 		assertAll(
 			() -> assertThat(삭제한_가이드.getContent()).isNull(),
 			() -> assertThat(삭제한_가이드.getComparedToLastWeek()).isNull(),
-			() -> assertThat(삭제한_가이드.getNeedStepByLastWeek()).isEqualTo(0),
-			() -> assertThat(삭제한_가이드.getNeedStepByTTS()).isEqualTo(0),
-			() -> assertThat(삭제한_가이드.getStepCount()).isEqualTo(0)
+			() -> assertThat(삭제한_가이드.getNeedStepByLastWeek()).isZero(),
+			() -> assertThat(삭제한_가이드.getNeedStepByTTS()).isZero(),
+			() -> assertThat(삭제한_가이드.getStepCount()).isZero()
 		);
 	}
 

--- a/src/test/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideGenerateServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideGenerateServiceTest.java
@@ -1,8 +1,12 @@
 package com.coniverse.dangjang.domain.guide.weight.service;
 
 import static com.coniverse.dangjang.fixture.AnalysisDataFixture.*;
+import static com.coniverse.dangjang.fixture.GuideFixture.*;
 import static com.coniverse.dangjang.fixture.UserFixture.*;
 import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
@@ -17,6 +21,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import com.coniverse.dangjang.domain.analysis.dto.healthMetric.WeightAnalysisData;
 import com.coniverse.dangjang.domain.analysis.strategy.WeightAnalysisStrategy;
+import com.coniverse.dangjang.domain.code.enums.CommonCode;
 import com.coniverse.dangjang.domain.guide.common.exception.GuideNotFoundException;
 import com.coniverse.dangjang.domain.guide.weight.document.WeightGuide;
 import com.coniverse.dangjang.domain.guide.weight.repository.WeightGuideRepository;
@@ -74,5 +79,20 @@ class WeightGuideGenerateServiceTest {
 		// then
 		WeightGuide 등록된_건강지표 = weightGuideRepository.findByOauthIdAndCreatedAt(테오_아이디, 등록_일자).orElseThrow(GuideNotFoundException::new);
 		assertThat(등록된_건강지표.getContent()).isEqualTo(weightGuideGenerateService.createContent((WeightAnalysisData)data));
+	}
+
+	@Test
+	void 체중_가이드를_성공적으로_삭제한다() {
+		// given
+		String oauthId = 테오_아이디;
+		String createdAt = 등록_일자;
+		weightGuideRepository.save(체중_가이드(oauthId, createdAt));
+
+		// when
+		weightGuideGenerateService.removeGuide(oauthId, LocalDate.parse(createdAt), CommonCode.MEASUREMENT);
+
+		// then
+		Optional<WeightGuide> 삭제된_가이드 = weightGuideRepository.findByOauthIdAndCreatedAt(oauthId, createdAt);
+		assertThat(삭제된_가이드).isEmpty();
 	}
 }

--- a/src/test/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideGenerateServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideGenerateServiceTest.java
@@ -85,7 +85,7 @@ class WeightGuideGenerateServiceTest {
 	void 체중_가이드를_성공적으로_삭제한다() {
 		// given
 		String oauthId = 테오_아이디;
-		String createdAt = 등록_일자;
+		String createdAt = "2023-11-01";
 		weightGuideRepository.save(체중_가이드(oauthId, createdAt));
 
 		// when

--- a/src/test/java/com/coniverse/dangjang/domain/healthmetric/controller/HealthMetricControllerTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/healthmetric/controller/HealthMetricControllerTest.java
@@ -45,6 +45,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class HealthMetricControllerTest extends ControllerTest {
 	public static final String URL = "/api/health-metric";
+	public static LocalDate 시작_날짜 = LocalDate.parse("2023-12-31");
+	public static LocalDate 마지막_날짜 = LocalDate.parse("2024-01-06");
+	public static LocalDate 생성_날짜 = LocalDate.of(2023, 12, 31);
+	public static List<BloodSugarMinMax> 혈당차트 = 혈당차트_생성(생성_날짜, 100, 200);
+	public static List<HealthMetricChartData> 체중차트 = 체중차트_생성(생성_날짜, 100);
+	public static List<HealthMetricChartData> 걸음수차트 = 걸음수차트_생성(생성_날짜, 10000);
+	public static List<HealthMetricChartData> 칼로리차트 = 칼로리차트_생성(생성_날짜, 400);
 	private final HealthMetricResponse response = 건강지표_등록_응답();
 	private String postContent;
 	private String patchContent;
@@ -54,13 +61,6 @@ class HealthMetricControllerTest extends ControllerTest {
 	private HealthMetricChartSearchService healthMetricChartSearchService;
 	@Autowired
 	private HealthMetricSearchService healthMetricSearchService;
-	public static LocalDate 시작_날짜 = LocalDate.parse("2023-12-31");
-	public static LocalDate 마지막_날짜 = LocalDate.parse("2024-01-06");
-	public static LocalDate 생성_날짜 = LocalDate.of(2023, 12, 31);
-	public static List<BloodSugarMinMax> 혈당차트 = 혈당차트_생성(생성_날짜, 100, 200);
-	public static List<HealthMetricChartData> 체중차트 = 체중차트_생성(생성_날짜, 100);
-	public static List<HealthMetricChartData> 걸음수차트 = 걸음수차트_생성(생성_날짜, 10000);
-	public static List<HealthMetricChartData> 칼로리차트 = 칼로리차트_생성(생성_날짜, 400);
 
 	@BeforeAll
 	void setUp() throws JsonProcessingException {
@@ -269,6 +269,60 @@ class HealthMetricControllerTest extends ControllerTest {
 			status().isOk(),
 			jsonPath("$.message").value("OK"),
 			jsonPath("$.data.date").value(response.date().toString())
+		);
+	}
+
+	@Test
+	void 건강지표를_성공적으로_삭제한다() throws Exception {
+		// given
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("date", "2021-01-01");
+		params.add("type", "아침식전");
+
+		// when
+		ResultActions resultActions = delete(mockMvc, URL, params);
+
+		// then
+		resultActions.andExpectAll(
+			status().isNoContent()
+		);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"2021-01-51", "2021-02-29", "2021-04-31", "2021-06-31", "2021-09-31", "2021-11-31", "2021.01.01", "2021/01/01", "2021-1-1"})
+	void 잘못된_날짜_parameter를_전달할_경우_400에러를_반환한다(String date) throws Exception {
+		// given
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("date", date);
+		params.add("type", "아침식전");
+
+		// when
+		ResultActions resultActions = delete(mockMvc, URL, params);
+
+		// then
+		resultActions.andExpectAll(
+			status().isBadRequest(),
+			jsonPath("$.errorCode").value(400),
+			jsonPath("$.violationErrors[0].rejectedValue").value(date)
+		);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {" ", ""})
+	void 잘못된_타입_parameter를_전달할_경우_400에러를_반환한다(String type) throws Exception {
+		// given
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("date", "2021-01-01");
+		params.add("type", type);
+
+		// when
+		ResultActions resultActions = delete(mockMvc, URL, params);
+
+		// then
+		resultActions.andExpectAll(
+			status().isBadRequest(),
+			jsonPath("$.errorCode").value(400),
+			jsonPath("$.violationErrors[0].rejectedValue").value(type)
 		);
 	}
 }

--- a/src/test/java/com/coniverse/dangjang/domain/healthmetric/service/HealthMetricRegisterServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/healthmetric/service/HealthMetricRegisterServiceTest.java
@@ -149,11 +149,11 @@ class HealthMetricRegisterServiceTest {
 	@Test
 	void 존재하지_않는_건강지표를_삭제할_경우_예외가_발생한다() {
 		// given
-		CommonCode type = 수정된_건강지표.getType();
-		LocalDate createdAt = 수정된_건강지표.getCreatedAt();
+		String type = 수정된_건강지표.getType().getTitle();
+		String createdAt = 수정된_건강지표.getCreatedAt().toString();
 
 		// when & then
-		assertThatThrownBy(() -> healthMetricRegisterService.remove(createdAt.toString(), type.getTitle(), oauthId))
+		assertThatThrownBy(() -> healthMetricRegisterService.remove(createdAt, type, oauthId))
 			.isInstanceOf(HealthMetricNotFoundException.class);
 	}
 }

--- a/src/test/java/com/coniverse/dangjang/domain/healthmetric/service/HealthMetricRegisterServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/healthmetric/service/HealthMetricRegisterServiceTest.java
@@ -5,6 +5,8 @@ import static com.coniverse.dangjang.fixture.UserFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.LocalDate;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
@@ -23,7 +25,9 @@ import com.coniverse.dangjang.domain.healthmetric.dto.request.HealthMetricPatchR
 import com.coniverse.dangjang.domain.healthmetric.dto.request.HealthMetricPostRequest;
 import com.coniverse.dangjang.domain.healthmetric.dto.response.HealthMetricResponse;
 import com.coniverse.dangjang.domain.healthmetric.entity.HealthMetric;
+import com.coniverse.dangjang.domain.healthmetric.exception.HealthMetricNotFoundException;
 import com.coniverse.dangjang.domain.healthmetric.repository.HealthMetricRepository;
+import com.coniverse.dangjang.domain.user.entity.User;
 import com.coniverse.dangjang.domain.user.repository.UserRepository;
 import com.coniverse.dangjang.global.util.EnumFindUtil;
 
@@ -45,12 +49,15 @@ class HealthMetricRegisterServiceTest {
 	private AnalysisService analysisService;
 	@MockBean
 	private GuideService guideService;
-	private String 테오_아이디;
+	private User user;
+	private String oauthId;
 	private HealthMetric 등록된_건강지표;
+	private HealthMetric 수정된_건강지표;
 
 	@BeforeAll
 	void setUp() {
-		테오_아이디 = userRepository.save(유저_테오()).getOauthId();
+		user = userRepository.save(유저_테오());
+		oauthId = user.getOauthId();
 	}
 
 	@AfterAll
@@ -66,17 +73,17 @@ class HealthMetricRegisterServiceTest {
 		HealthMetricPostRequest request = 건강지표_등록_요청();
 
 		// when
-		HealthMetricResponse response = healthMetricRegisterService.register(request, 테오_아이디);
+		HealthMetricResponse response = healthMetricRegisterService.register(request, oauthId);
 
 		// then
 		등록된_건강지표 = healthMetricRepository
-			.findByHealthMetricId(테오_아이디, response.createdAt(), EnumFindUtil.findByTitle(CommonCode.class, response.type())).orElseThrow();
+			.findByHealthMetricId(oauthId, response.createdAt(), EnumFindUtil.findByTitle(CommonCode.class, response.type())).orElseThrow();
 
 		assertAll(
 			() -> assertThat(등록된_건강지표.getType().getTitle()).isEqualTo(request.type()),
 			() -> assertThat(등록된_건강지표.getUnit()).isEqualTo(request.unit()),
 			() -> assertThat(등록된_건강지표.getCreatedAt()).isEqualTo(request.createdAt()),
-			() -> assertThat(등록된_건강지표.getOauthId()).isEqualTo(테오_아이디)
+			() -> assertThat(등록된_건강지표.getOauthId()).isEqualTo(oauthId)
 		);
 	}
 
@@ -87,12 +94,12 @@ class HealthMetricRegisterServiceTest {
 		HealthMetricPatchRequest request = 단위_변경한_건강지표_수정_요청();
 
 		// when
-		HealthMetricResponse response = healthMetricRegisterService.update(request, 테오_아이디);
+		HealthMetricResponse response = healthMetricRegisterService.update(request, oauthId);
 
 		// then
 
 		HealthMetric 수정된_건강지표 = healthMetricRepository
-			.findByHealthMetricId(테오_아이디, response.createdAt(), EnumFindUtil.findByTitle(CommonCode.class, response.type())).orElseThrow();
+			.findByHealthMetricId(oauthId, response.createdAt(), EnumFindUtil.findByTitle(CommonCode.class, response.type())).orElseThrow();
 
 		assertAll(
 			() -> assertThat(수정된_건강지표.getUnit()).isNotEqualTo(등록된_건강지표.getUnit()),
@@ -110,11 +117,11 @@ class HealthMetricRegisterServiceTest {
 		HealthMetricPatchRequest request = 타입_변경한_건강지표_수정_요청();
 
 		// when
-		HealthMetricResponse response = healthMetricRegisterService.update(request, 테오_아이디);
+		HealthMetricResponse response = healthMetricRegisterService.update(request, oauthId);
 
 		// then
-		HealthMetric 수정된_건강지표 = healthMetricRepository
-			.findByHealthMetricId(테오_아이디, response.createdAt(), EnumFindUtil.findByTitle(CommonCode.class, response.type())).orElseThrow();
+		수정된_건강지표 = healthMetricRepository
+			.findByHealthMetricId(oauthId, response.createdAt(), EnumFindUtil.findByTitle(CommonCode.class, response.type())).orElseThrow();
 
 		assertAll(
 			() -> assertThat(수정된_건강지표.getType().getTitle()).isEqualTo(request.newType()),
@@ -122,5 +129,31 @@ class HealthMetricRegisterServiceTest {
 			() -> assertThat(수정된_건강지표.getOauthId()).isEqualTo(등록된_건강지표.getOauthId()),
 			() -> assertThat(수정된_건강지표.getType()).isNotEqualTo(등록된_건강지표.getType())
 		);
+	}
+
+	@Order(300)
+	@Test
+	void 건강지표를_성공적으로_삭제한다() {
+		// given
+		CommonCode type = 수정된_건강지표.getType();
+		LocalDate createdAt = 수정된_건강지표.getCreatedAt();
+
+		// when
+		healthMetricRegisterService.remove(createdAt.toString(), type.getTitle(), oauthId);
+
+		// then
+		assertThat(healthMetricRepository.findByHealthMetricId(oauthId, createdAt, type)).isEmpty();
+	}
+
+	@Order(400)
+	@Test
+	void 존재하지_않는_건강지표를_삭제할_경우_예외가_발생한다() {
+		// given
+		CommonCode type = 수정된_건강지표.getType();
+		LocalDate createdAt = 수정된_건강지표.getCreatedAt();
+
+		// when & then
+		assertThatThrownBy(() -> healthMetricRegisterService.remove(createdAt.toString(), type.getTitle(), oauthId))
+			.isInstanceOf(HealthMetricNotFoundException.class);
 	}
 }

--- a/src/test/java/com/coniverse/dangjang/fixture/GuideFixture.java
+++ b/src/test/java/com/coniverse/dangjang/fixture/GuideFixture.java
@@ -78,11 +78,7 @@ public class GuideFixture {
 
 		return ExerciseGuide.builder()
 			.oauthId(oauthId)
-			.needStepByLastWeek(0)
-			.comparedToLastWeek("저번주 대비 가이드입니다.")
-			.content("가이드 내용입니다.")
 			.createdAt(조회_날짜)
-			.stepCount(0)
 			.exerciseCalories(exerciseCalories)
 			.build();
 	}
@@ -118,8 +114,7 @@ public class GuideFixture {
 	}
 
 	public static WeightGuideResponse 체중_가이드_응답(String createdAt) {
-		return new WeightGuideResponse(CommonCode.MEASUREMENT.getTitle(), createdAt, 20, Alert.LEVEL_1_OBESITY.getTitle(), "가이드입니다", 18.0,
-			"50");
+		return new WeightGuideResponse(CommonCode.MEASUREMENT.getTitle(), createdAt, 20, Alert.LEVEL_1_OBESITY.getTitle(), "가이드입니다", 18.0, "50");
 	}
 
 	public static ExerciseGuideResponse 운동_가이드_응답(String 조회_날짜) {
@@ -131,10 +126,6 @@ public class GuideFixture {
 		double percent = ExerciseCoefficient.findCoefficientByType(type);
 		int calorie = (int)(percent * weight / 15 * unit);
 		return new ExerciseCalorie(type, calorie, unit);
-	}
-
-	public static GuideResponse 당화혈색소_가이드_응답() { // TODO return 수정
-		return null;
 	}
 
 	public static List<ExerciseGuide> 운동가이드_리스트(User user, LocalDate createdAt, int unit, int needCount) {
@@ -150,7 +141,6 @@ public class GuideFixture {
 				.stepCount(8000)
 				.createdAt(createdAt.plusDays(n))
 				.build()).collect(Collectors.toList());
-
 	}
 
 	public static DayGuideResponse 하루_가이드_응답(User user, LocalDate date, List<TodayGuide> 혈당가이드, WeightDayGuide 체중가이드, ExerciseDayGuide 운동가이드) {
@@ -164,5 +154,4 @@ public class GuideFixture {
 	public static ExerciseDayGuide 운동_하루_가이드() {
 		return new ExerciseDayGuide(1400, 11000);
 	}
-
 }

--- a/src/test/java/com/coniverse/dangjang/support/SimpleMockMvc.java
+++ b/src/test/java/com/coniverse/dangjang/support/SimpleMockMvc.java
@@ -87,4 +87,13 @@ public class SimpleMockMvc {
 				.accept(MediaType.APPLICATION_JSON)
 		);
 	}
+
+	public static ResultActions delete(final MockMvc mockMvc, final String uri, final MultiValueMap<String, String> params,
+		final Object... pathVariables) throws Exception {
+		return mockMvc.perform(
+			MockMvcRequestBuilders.delete(uri, pathVariables)
+				.params(params)
+				.accept(MediaType.APPLICATION_JSON)
+		);
+	}
 }


### PR DESCRIPTION
# Changes 📝
- 건강지표 삭제
- 혈당 가이드 삭제
- 운동 가이드 삭제
- 체중 가이드 삭제

## Details 🌼
### 건강지표
건강지표 삭제 -> type에 따라 각 가이드 삭제로 전파

### 혈당 가이드
타입에 해당하는 서브 가이드를 삭제합니다
서브 가이드가 더 이상 존재하지 않을 경우 혈당 가이드를 삭제합니다.

### 운동 가이드
`걸음 수` 타입일 경우 걸음 수 관련 필드를 초기화합니다 걸음 수 관련 필드는 **하나의 클래스로 묶어서 관리하도록 리팩토링하는게 좋을 것 같아요**

운동 관련 타입일 경우 `List<ExerciseCalorie>`에서 찾아서 삭제합니다
걸음 수 관련 필드도 없고, `List<ExerciseCalorie>`도 비어있을 경우 운동 가이드를 삭제합니다.

### 체중 가이드
체중 가이드를 조회해서 삭제합니다 (가장 간단)

## Check List ☑️
- [x] 테스트 코드를 통과했다.
- [x] merge할 브랜치의 위치를 확인했다. (main ❌)
- [x] Assignee를 지정했다.
- [x] Label을 지정했다.
