### PR TITLE
hotfix 로그 버전 숫자 1자리만 허용되는 문제 수정

### DIFF
--- a/src/main/java/com/coniverse/dangjang/domain/log/dto/request/LogRequest.java
+++ b/src/main/java/com/coniverse/dangjang/domain/log/dto/request/LogRequest.java
@@ -14,6 +14,6 @@ import jakarta.validation.constraints.Positive;
  * @since 1.0.0
  */
 public record LogRequest(@NotBlank String eventLogName, @NotBlank String screenName, @Positive int logVersion,
-						 @NotBlank @Pattern(regexp = "^\\d+\\.\\d+\\.\\d$") String appVersion, @NotBlank String sessionId,
+						 @NotBlank @Pattern(regexp = "^\\d+\\.\\d+\\.\\d+$") String appVersion, @NotBlank String sessionId,
 						 @NotNull Map<@NotBlank String, Object> logData) {
 }


### PR DESCRIPTION
# Changes 📝
- 로그 dto 정규식

## Details 🌼
![스크린샷 2023-11-05 오후 7 34 36](https://github.com/co-niverse/dangjang-backend/assets/101033262/d8910dbe-0b45-46a3-aa2a-e497ad537f53)

`+` 누락으로 하나의 숫자만 허용되는 이슈가 발생하여 이를 반영합니다
