### PR TITLE
[Hotfix]: v1.3.2 version api dto 정규식 수정

### DIFF
--- a/src/main/java/com/coniverse/dangjang/domain/version/dto/request/VersionRequest.java
+++ b/src/main/java/com/coniverse/dangjang/domain/version/dto/request/VersionRequest.java
@@ -9,6 +9,6 @@ import jakarta.validation.constraints.Pattern;
  * @author TEO
  * @since 1.3.0
  */
-public record VersionRequest(@NotBlank @Pattern(regexp = "^\\d\\.\\d\\.\\d$") String minVersion,
-							 @NotBlank @Pattern(regexp = "^\\d\\.\\d\\.\\d$") String latestVersion, @NotBlank String key) {
+public record VersionRequest(@NotBlank @Pattern(regexp = "^\\d+\\.\\d+\\.\\d+$") String minVersion,
+							 @NotBlank @Pattern(regexp = "^\\d+\\.\\d+\\.\\d+$") String latestVersion, @NotBlank String key) {
 }


### PR DESCRIPTION
# Changes 📝
- version dto 정규식

## Details 🌼
![스크린샷 2023-11-06 오후 3 02 47](https://github.com/co-niverse/dangjang-backend/assets/101033262/2345e2d0-b3da-4b2a-b0e4-514c10c8cde1)

`+` 누락으로 하나의 숫자만 허용되는 이슈가 발생하여 이를 반영합니다