### PR TITLE
포인트 상품 목록 조회 불가

### DIFF
--- a/src/main/java/com/coniverse/dangjang/domain/point/service/PointService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/point/service/PointService.java
@@ -1,6 +1,7 @@
 package com.coniverse.dangjang.domain.point.service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -181,13 +182,14 @@ public class PointService {
 	 * 구매 가능 상품 조회
 	 * <p>
 	 * 유저의 현재 포인트와 구매 가능한 상품을 조회한다.
+	 * 11월 10일 이후 포인트 서비스를 종료한다.
 	 *
 	 * @param oauthId 유저 아이디
 	 * @since 1.0.0
 	 */
 	public ProductListResponse getProducts(String oauthId) {
 		int balancePoint = pointSearchService.findUserPointByOauthId(oauthId).getPoint();
-		List<PointProduct> productList = pointSearchService.findAllByType(PointType.USE);
+		List<PointProduct> productList = new ArrayList<>();
 		List<String> descriptionListToEarnPoint = pointSearchService.findAllByType(PointType.EARN).stream()
 			.map(PointProduct::getDescription)
 			.collect(Collectors.toList());

--- a/src/test/java/com/coniverse/dangjang/domain/point/service/PointHistoryServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/point/service/PointHistoryServiceTest.java
@@ -281,7 +281,6 @@ class PointHistoryServiceTest {
 		ProductListResponse response = pointService.getProducts(유저.getOauthId());
 		//then
 		assertThat(response.balancedPoint()).isEqualTo(유저_포인트.getPoint());
-		assertThat(response.productList()).hasSize(useTypeProductSize);
 		assertThat(response.descriptionListToEarnPoint()).hasSize(earnTypeProductSize);
 	}
 


### PR DESCRIPTION
# Changes 📝
포인트 상품 목록 조회 불가

## Details 🌼
- 포인트 상품 구매 이벤트가 종료됨에 따라, 10일 이후로 상품 구매가 불가능합니다.
- 포인트 상품 조회시, 구매 가능한 상품 목록 개수는 0입니다.

## Check List ☑️
- [x] 테스트 코드를 통과했다.
- [x] merge할 브랜치의 위치를 확인했다. (main ❌)
- [x] Assignee를 지정했다.
- [x] Label을 지정했다.
