### PR TITLE
운동,체중 가이드 중복 처리

### DIFF
--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/document/ExerciseGuide.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/document/ExerciseGuide.java
@@ -65,6 +65,35 @@ public class ExerciseGuide { // TODO 걸음 가이드, 칼로리 가이드로 �
 	}
 
 	/**
+	 * 걸음수와 관련된 속성들 중복 여부 판별
+	 *
+	 * @param needStepByTTS      만보 대비 필요한 걸음수
+	 * @param needStepByLastWeek 지난주 평균 걸음수 대비 필요한 걸음수
+	 * @param comparedToLastWeek 지난주 걸음수와 비교한 가이드
+	 * @param content            만보 대비 걸음수에 대한 가이드
+	 * @return 중복 여부
+	 * @since 1.6.0
+	 */
+	public boolean isDuplicateAboutStepCount(int needStepByTTS, int needStepByLastWeek, String comparedToLastWeek, String content, int stepCount) {
+		if (this.needStepByTTS == needStepByTTS && this.needStepByLastWeek == needStepByLastWeek && this.comparedToLastWeek == comparedToLastWeek
+			&& this.content == content && this.stepCount == stepCount) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * 걸음수와 관련된 속성들 중복 여부 판별
+	 *
+	 * @param exerciseCalorie 운동 칼로리
+	 * @return 중복 여부
+	 * @since 1.6.0
+	 */
+	public boolean isDuplicateAboutExerciseCalories(ExerciseCalorie exerciseCalorie) {
+		return this.exerciseCalories.stream().filter(exercise -> exercise.type().equals(exerciseCalorie.type())).findFirst().isPresent();
+	}
+
+	/**
 	 * 수정된 운동 칼로리를 업데이트한다.
 	 * <p>
 	 * 기존에 존재하는 운동 칼로리를 삭제하고, 새로운 운동 칼로리를 추가한다.

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/document/ExerciseGuide.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/document/ExerciseGuide.java
@@ -72,7 +72,7 @@ public class ExerciseGuide { // TODO 걸음 가이드, 칼로리 가이드로 �
 	 * @param comparedToLastWeek 지난주 걸음수와 비교한 가이드
 	 * @param content            만보 대비 걸음수에 대한 가이드
 	 * @return 중복 여부
-	 * @since 1.6.0
+	 * @since 1.6.1
 	 */
 	public boolean isDuplicateAboutStepCount(int needStepByTTS, int needStepByLastWeek, String comparedToLastWeek, String content, int stepCount) {
 		if (this.needStepByTTS == needStepByTTS && this.needStepByLastWeek == needStepByLastWeek && this.comparedToLastWeek == comparedToLastWeek
@@ -87,7 +87,7 @@ public class ExerciseGuide { // TODO 걸음 가이드, 칼로리 가이드로 �
 	 *
 	 * @param exerciseCalorie 운동 칼로리
 	 * @return 중복 여부
-	 * @since 1.6.0
+	 * @since 1.6.1
 	 */
 	public boolean isDuplicateAboutExerciseCalories(ExerciseCalorie exerciseCalorie) {
 		return this.exerciseCalories.stream().filter(exercise -> exercise.type().equals(exerciseCalorie.type())).findFirst().isPresent();

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/document/ExerciseGuide.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/document/ExerciseGuide.java
@@ -77,9 +77,9 @@ public class ExerciseGuide { // TODO 걸음 가이드, 칼로리 가이드로 �
 	public boolean isDuplicateAboutStepCount(int needStepByTTS, int needStepByLastWeek, String comparedToLastWeek, String content, int stepCount) {
 		if (this.needStepByTTS == needStepByTTS && this.needStepByLastWeek == needStepByLastWeek && this.comparedToLastWeek == comparedToLastWeek
 			&& this.content == content && this.stepCount == stepCount) {
-			return false;
+			return true;
 		}
-		return true;
+		return false;
 	}
 
 	/**

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateService.java
@@ -64,17 +64,19 @@ public class ExerciseGuideGenerateService implements GuideGenerateService { // T
 			return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(newExerciseGuide));
 		}
 		// 걸음 수 추가
-		if (exerciseAnalysisData.getType().equals(CommonCode.STEP_COUNT)) {
+		if (exerciseAnalysisData.getType().equals(CommonCode.STEP_COUNT) && existExerciseGuide.getStepCount() == 0) {
 			existExerciseGuide.changeAboutWalk(exerciseAnalysisData.needStepByTTS, exerciseAnalysisData.needStepByLastWeek,
 				walkGuideContent.getGuideLastWeek(), walkGuideContent.getGuideTTS(), exerciseAnalysisData.getUnit());
 			return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(existExerciseGuide));
 		}
-		//운동 추가
 		ExerciseCalorie exerciseCalorie = new ExerciseCalorie(exerciseAnalysisData.getType(), exerciseAnalysisData.getCalorie(),
 			exerciseAnalysisData.getUnit());
-		existExerciseGuide.changeExerciseCalories(exerciseCalorie);
-		return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(existExerciseGuide));
-
+		//운동 추가
+		if (!existExerciseGuide.getExerciseCalories().contains(exerciseCalorie)) {
+			existExerciseGuide.changeExerciseCalories(exerciseCalorie);
+			return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(existExerciseGuide));
+		}
+		return exerciseGuideMapper.toResponse(existExerciseGuide);
 	}
 
 	/**

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateService.java
@@ -71,13 +71,14 @@ public class ExerciseGuideGenerateService implements GuideGenerateService { // T
 					walkGuideContent.getGuideLastWeek(), walkGuideContent.getGuideTTS(), exerciseAnalysisData.getUnit());
 				return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(existExerciseGuide));
 			}
-		}
-		ExerciseCalorie exerciseCalorie = new ExerciseCalorie(exerciseAnalysisData.getType(), exerciseAnalysisData.getCalorie(),
-			exerciseAnalysisData.getUnit());
-		//운동 추가
-		if (!existExerciseGuide.isDuplicateAboutExerciseCalories(exerciseCalorie)) {
-			existExerciseGuide.changeExerciseCalories(exerciseCalorie);
-			return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(existExerciseGuide));
+		} else {
+			ExerciseCalorie exerciseCalorie = new ExerciseCalorie(exerciseAnalysisData.getType(), exerciseAnalysisData.getCalorie(),
+				exerciseAnalysisData.getUnit());
+			//운동 추가
+			if (!existExerciseGuide.isDuplicateAboutExerciseCalories(exerciseCalorie)) {
+				existExerciseGuide.changeExerciseCalories(exerciseCalorie);
+				return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(existExerciseGuide));
+			}
 		}
 		return exerciseGuideMapper.toResponse(existExerciseGuide);
 	}

--- a/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/exercise/service/ExerciseGuideGenerateService.java
@@ -64,15 +64,18 @@ public class ExerciseGuideGenerateService implements GuideGenerateService { // T
 			return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(newExerciseGuide));
 		}
 		// 걸음 수 추가
-		if (exerciseAnalysisData.getType().equals(CommonCode.STEP_COUNT) && existExerciseGuide.getStepCount() == 0) {
-			existExerciseGuide.changeAboutWalk(exerciseAnalysisData.needStepByTTS, exerciseAnalysisData.needStepByLastWeek,
-				walkGuideContent.getGuideLastWeek(), walkGuideContent.getGuideTTS(), exerciseAnalysisData.getUnit());
-			return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(existExerciseGuide));
+		if (exerciseAnalysisData.getType().equals(CommonCode.STEP_COUNT)) {
+			if (!existExerciseGuide.isDuplicateAboutStepCount(exerciseAnalysisData.needStepByTTS, exerciseAnalysisData.needStepByLastWeek,
+				walkGuideContent.getGuideLastWeek(), walkGuideContent.getGuideTTS(), exerciseAnalysisData.getUnit())) {
+				existExerciseGuide.changeAboutWalk(exerciseAnalysisData.needStepByTTS, exerciseAnalysisData.needStepByLastWeek,
+					walkGuideContent.getGuideLastWeek(), walkGuideContent.getGuideTTS(), exerciseAnalysisData.getUnit());
+				return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(existExerciseGuide));
+			}
 		}
 		ExerciseCalorie exerciseCalorie = new ExerciseCalorie(exerciseAnalysisData.getType(), exerciseAnalysisData.getCalorie(),
 			exerciseAnalysisData.getUnit());
 		//운동 추가
-		if (!existExerciseGuide.getExerciseCalories().contains(exerciseCalorie)) {
+		if (!existExerciseGuide.isDuplicateAboutExerciseCalories(exerciseCalorie)) {
 			existExerciseGuide.changeExerciseCalories(exerciseCalorie);
 			return exerciseGuideMapper.toResponse(exerciseGuideRepository.save(existExerciseGuide));
 		}

--- a/src/main/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideGenerateService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/guide/weight/service/WeightGuideGenerateService.java
@@ -10,6 +10,7 @@ import com.coniverse.dangjang.domain.analysis.dto.healthMetric.WeightAnalysisDat
 import com.coniverse.dangjang.domain.code.enums.CommonCode;
 import com.coniverse.dangjang.domain.code.enums.GroupCode;
 import com.coniverse.dangjang.domain.guide.common.dto.response.GuideResponse;
+import com.coniverse.dangjang.domain.guide.common.exception.GuideNotFoundException;
 import com.coniverse.dangjang.domain.guide.common.service.GuideGenerateService;
 import com.coniverse.dangjang.domain.guide.weight.document.WeightGuide;
 import com.coniverse.dangjang.domain.guide.weight.mapper.WeightMapper;
@@ -42,8 +43,14 @@ public class WeightGuideGenerateService implements GuideGenerateService {
 	public GuideResponse createGuide(AnalysisData analysisData) {
 		WeightAnalysisData data = (WeightAnalysisData)analysisData;
 		String content = createContent(data);
-		WeightGuide weightGuide = weightMapper.toDocument(data, content);
-		return weightMapper.toResponse(mongoTemplate.save(weightGuide));
+		WeightGuide existWeightGuide;
+		try {
+			existWeightGuide = weightGuideSearchService.findByUserIdAndCreatedAt(data.getOauthId(), data.getCreatedAt().toString());
+		} catch (GuideNotFoundException e) {
+			WeightGuide weightGuide = weightMapper.toDocument(data, content);
+			return weightMapper.toResponse(mongoTemplate.save(weightGuide));
+		}
+		return weightMapper.toResponse(existWeightGuide);
 	}
 
 	/**

--- a/src/main/java/com/coniverse/dangjang/domain/point/service/PointService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/point/service/PointService.java
@@ -1,7 +1,6 @@
 package com.coniverse.dangjang.domain.point.service;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -189,7 +188,7 @@ public class PointService {
 	 */
 	public ProductListResponse getProducts(String oauthId) {
 		int balancePoint = pointSearchService.findUserPointByOauthId(oauthId).getPoint();
-		List<PointProduct> productList = new ArrayList<>();
+		List<PointProduct> productList = pointSearchService.findAllByType(PointType.USE);
 		List<String> descriptionListToEarnPoint = pointSearchService.findAllByType(PointType.EARN).stream()
 			.map(PointProduct::getDescription)
 			.collect(Collectors.toList());


### PR DESCRIPTION
# Changes 📝
- 운동, 체중 가이드 중복 처리
- 데모 시연을 위해 포인트 교환 목록 전달

## Details 🌼
- 운동, 체중 가이드 저장시, 중복되는 가이드라면 예외를 반환하지 않고 새로운 저장도 하지 않습니다.
    - 기존에 존재하는 가이드를 response로 전달

## Check List ☑️
- [x] 테스트 코드를 통과했다.
- [x] merge할 브랜치의 위치를 확인했다. (main ❌)
- [x] Assignee를 지정했다.
- [x] Label을 지정했다.

