### PR TITLE
notification 생성 메서드 보류

### DIFF
--- a/src/main/java/com/coniverse/dangjang/domain/scheduler/service/SchedulerService.java
+++ b/src/main/java/com/coniverse/dangjang/domain/scheduler/service/SchedulerService.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.launch.JobLauncher;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
@@ -36,8 +35,9 @@ public class SchedulerService {
 	 *
 	 * @author EVE
 	 * @since 1.1.0
+	 * @deprecated 서버가 이전될 때까지 사용하지 않는다
 	 */
-	@Scheduled(cron = "0 0 18 * * *", zone = "Asia/Seoul")
+
 	@SchedulerLock(name = "SchedulerService_makeNotification", lockAtLeastFor = "PT60S", lockAtMostFor = "PT70S")
 	public void makeNotification() {
 		List<FcmMessage> fcmMessage = notificationService.makeAccessFcmMessage();


### PR DESCRIPTION
# Changes 📝
- notification 생성 메서드 보류

## Details 🌼
- 서버가 안정적으로 이전되고, 서비스가 정상화될때까지 push 알림을 전달하지 않는다.

## Check List ☑️
- [x] 테스트 코드를 통과했다.
- [x] merge할 브랜치의 위치를 확인했다. (main ❌)
- [x] Assignee를 지정했다.
- [x] Label을 지정했다.


