### PR TITLE
접속 알림 메세지 전송 기준 개선

### DIFF
--- a/src/main/java/com/coniverse/dangjang/domain/notification/enums/FCMContent.java
+++ b/src/main/java/com/coniverse/dangjang/domain/notification/enums/FCMContent.java
@@ -1,0 +1,75 @@
+package com.coniverse.dangjang.domain.notification.enums;
+
+import lombok.AllArgsConstructor;
+
+/**
+ * FCM Message 내용 구성
+ * <p>
+ * 접속하지 않은 날짜에 따라 title과 body 내용을 달르게 구성한다.
+ * 접속하지 않은 날짜 기준은 1일전,3일전,7일전,2주전,한달전으로 구성된다.
+ * </p>
+ *
+ * @author EVE
+ * @since 1.7.0
+ */
+@AllArgsConstructor
+public enum FCMContent {
+	TITLE("오늘의 건강 상태는?", "오늘 접속하지 않았어요!", "당뇨 관리 작심삼일?!", "일주일 동안의 건강 상태 확인하기", "2주간 나의 건강 변화 기록하기", "한 달 동안의 나의 건강 상태는?!"),
+	BODY("꾸준히 기록하고, 건강 상태를 비교해 봐요!", "어제 이어서 오늘도 열심히 건강을 관리해 봐요 ", "3일 동안 접속하지 않았어요~ 다시 건강을 관리해 봐요!", "일주일 동안의 상태를 기록하고 확인해 봐요 !",
+		"2주 동안의 변화가 궁금하지 않으세요? 접속해서 건강 상태를 확인해 봐요 ! ", "오랜만에 건강 상태를 확인해볼까요?");
+	private final String defaultMessage;
+	private final String day1;
+	private final String day3;
+	private final String day7;
+	private final String day14;
+	private final String day30;
+
+	/**
+	 * 접속하지 않은 기간에 맞춰 title을 반환한다
+	 *
+	 * @param dateDiff 접속하지 않은 기간
+	 * @return title
+	 * @since 1.7.0
+	 */
+	public String getTitle(int dateDiff) {
+		switch (dateDiff) {
+			case 1:
+				return this.day1;
+			case 3:
+				return this.day3;
+			case 7:
+				return this.day7;
+			case 14:
+				return this.day14;
+			case 30:
+				return this.day30;
+			default:
+				return this.defaultMessage;
+		}
+	}
+
+	/**
+	 * 접속하지 않은 기간에 맞춰 body를 반환한다
+	 *
+	 * @param dateDiff 접속하지 않은 기간
+	 * @return body
+	 * @since 1.7.0
+	 */
+	public String getBody(int dateDiff) {
+		switch (dateDiff) {
+			case 1:
+				return this.day1;
+			case 3:
+				return this.day3;
+			case 7:
+				return this.day7;
+			case 14:
+				return this.day14;
+			case 30:
+				return this.day30;
+			default:
+				return this.defaultMessage;
+		}
+	}
+
+}

--- a/src/main/java/com/coniverse/dangjang/domain/notification/repository/UserFcmTokenRepository.java
+++ b/src/main/java/com/coniverse/dangjang/domain/notification/repository/UserFcmTokenRepository.java
@@ -22,11 +22,11 @@ public interface UserFcmTokenRepository extends JpaRepository<UserFcmToken, FcmI
 	 * 접속하지 않은, 유저의 fcmToken을 조회한다.
 	 * 최근 접속일이 1일 전, 3일 전, 일주일 전, 2주 전, 한달 전인 유저들만 조회한다.
 	 *
-	 * @param date 조회 날짜
+	 * @param compareDate 비교 날짜
 	 * @since 1.1.0
 	 */
-	@Query("SELECT utk FROM UserFcmToken utk WHERE DATEDIFF(:date,utk.user.accessedAt) IN (1,3,7,14,30) ")
-	List<UserFcmToken> findNotAccessUserFcmToken(@Param("date") LocalDate date);
+	@Query(value = "SELECT utk FROM UserFcmToken utk WHERE FUNCTION('TIMESTAMPDIFF', DAY,  utk.user.accessedAt , :compareDate ) IN (1, 3, 7, 14, 30)")
+	List<UserFcmToken> findNotAccessUserFcmToken(@Param("compareDate") LocalDate compareDate);
 
 	/**
 	 * FcmId로 UserFcmToken을 조회한다

--- a/src/main/java/com/coniverse/dangjang/domain/notification/repository/UserFcmTokenRepository.java
+++ b/src/main/java/com/coniverse/dangjang/domain/notification/repository/UserFcmTokenRepository.java
@@ -20,11 +20,12 @@ import com.coniverse.dangjang.domain.notification.entity.UserFcmToken;
 public interface UserFcmTokenRepository extends JpaRepository<UserFcmToken, FcmId> {
 	/**
 	 * 접속하지 않은, 유저의 fcmToken을 조회한다.
+	 * 최근 접속일이 1일 전, 3일 전, 일주일 전, 2주 전, 한달 전인 유저들만 조회한다.
 	 *
 	 * @param date 조회 날짜
 	 * @since 1.1.0
 	 */
-	@Query("SELECT utk FROM UserFcmToken utk where utk.user.accessedAt < :date")
+	@Query("SELECT utk FROM UserFcmToken utk WHERE DATEDIFF(:date,utk.user.accessedAt) IN (1,3,7,14,30) ")
 	List<UserFcmToken> findNotAccessUserFcmToken(@Param("date") LocalDate date);
 
 	/**

--- a/src/test/java/com/coniverse/dangjang/domain/scheduler/service/SchedulerServiceTest.java
+++ b/src/test/java/com/coniverse/dangjang/domain/scheduler/service/SchedulerServiceTest.java
@@ -2,7 +2,6 @@ package com.coniverse.dangjang.domain.scheduler.service;
 
 import static com.coniverse.dangjang.fixture.NotificationFixture.*;
 import static com.coniverse.dangjang.fixture.UserFixture.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
 
@@ -25,6 +24,7 @@ import com.coniverse.dangjang.domain.user.repository.UserRepository;
  * @author EVE
  * @since 1.1.0
  */
+
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest
 class SchedulerServiceTest {
@@ -73,6 +73,6 @@ class SchedulerServiceTest {
 		schedulerService.makeNotification();
 		//when
 		//then
-		assertDoesNotThrow(() -> schedulerService.makeNotification());
+
 	}
 }


### PR DESCRIPTION
# Changes 📝
접속 알림 메세지 전송 기준을 개선하였습니다.

## Details 🌼
최근 접속일에 따라 메세지를 달리 전송합니다.
- 메세지 전송 기준
    - 최근 접속일이 어제인 경우 , 최근 접속일이 3일 지난 경우 , 7일 지난 경우, 14일 지난 경우, 한달 지난 경우 접속관련 알림 메세지를 전송합니다.
- 접속일에 따라 메세지 title ,body 변경 
    - Enum으로 관리하고 있으나, 하드코딩 느낌이 강함 -> 개선 필요,,  

## Check List ☑️
- [ ] 테스트 코드를 통과했다.
- [ ] merge할 브랜치의 위치를 확인했다. (main ❌)
- [ ] Assignee를 지정했다.
- [ ] Label을 지정했다.

